### PR TITLE
[hal/driver/rp2040] fix quality.py findings: macro align, NVIC guard, clock exemption

### DIFF
--- a/document/agent/skills/README.md
+++ b/document/agent/skills/README.md
@@ -7,10 +7,10 @@
 对 code agent 说：
 
 ```
-安装 document/agent/skills/ 下的 vsf-bench 和 vsf-hal-driver 到项目 skills
+用软链接安装 document/agent/skills/ 下的 vsf-bench 和 vsf-hal-driver 到项目 skills
 ```
 
-Agent 会自动识别 `SKILL.md` 入口，默认安装为项目级 skill（仅当前项目生效）。
+Agent 会自动识别 `SKILL.md` 入口，**用软链接（`ln -s` / `New-Item -ItemType Junction`）而非复制**，这样多项目共享同一份 skill、升级时自动同步。
 
 如果需要在所有项目中使用，告诉 agent "安装到用户 skills" 即可。
 

--- a/source/hal/driver/RaspberryPi/RP2040/adc/adc.c
+++ b/source/hal/driver/RaspberryPi/RP2040/adc/adc.c
@@ -73,7 +73,7 @@ static inline void __vsf_hw_adc_irq_clear_pending(adc_hw_t *reg)
 vsf_err_t VSF_MCONNECT(VSF_ADC_CFG_IMP_PREFIX, _adc_init)(
     VSF_MCONNECT(VSF_ADC_CFG_IMP_PREFIX, _adc_t) *adc_ptr,
     vsf_adc_cfg_t *cfg_ptr
-)
+)   // no clock gate: RP2040 ADC has no per-instance clock gate; clk_adc configured globally in driver.c
 {
     VSF_HAL_ASSERT(NULL != adc_ptr);
     VSF_HAL_ASSERT(NULL != cfg_ptr);
@@ -427,7 +427,8 @@ static void VSF_MCONNECT(__, VSF_ADC_CFG_IMP_PREFIX, _adc_irqhandler)(
                                         __IDX, _REG),                           \
         .rst_bit = VSF_MCONNECT(VSF_ADC_CFG_IMP_UPCASE_PREFIX, _ADC, __IDX,     \
                                 _RST_BIT),                                      \
-        .irqn    = VSF_MCONNECT(VSF_ADC_CFG_IMP_UPCASE_PREFIX, _ADC, __IDX, _IRQN), \
+        .irqn =                                                                 \
+            VSF_MCONNECT(VSF_ADC_CFG_IMP_UPCASE_PREFIX, _ADC, __IDX, _IRQN),    \
         __HAL_OP};                                                              \
     VSF_CAL_ROOT void VSF_MCONNECT(VSF_ADC_CFG_IMP_UPCASE_PREFIX, _ADC, __IDX,  \
                                    _IRQHandler)(void) {                         \

--- a/source/hal/driver/RaspberryPi/RP2040/dma/dma.c
+++ b/source/hal/driver/RaspberryPi/RP2040/dma/dma.c
@@ -125,7 +125,8 @@ vsf_err_t VSF_MCONNECT(VSF_DMA_CFG_IMP_PREFIX, _dma_init)(
     }
 
     for (uint8_t irq_idx = 0; irq_idx < VSF_HW_DMA0_IRQ_Handler_COUNT; irq_idx++) {
-        if (cfg_ptr->prio != vsf_arch_prio_invalid) {
+        if ((cfg_ptr->prio != vsf_arch_prio_invalid)
+            && (cfg_ptr->isr.handler_fn != NULL)) {
             NVIC_SetPriority(dma_ptr->irqn[irq_idx], cfg_ptr->prio);
             NVIC_EnableIRQ(dma_ptr->irqn[irq_idx]);
         } else {


### PR DESCRIPTION
Fix three quality.py findings on RP2040 drivers, all surfaced by the
vsf-hal-driver skill's static checks.

## Changes

### 1. `source/hal/driver/RaspberryPi/RP2040/adc/adc.c`
- **macro-backslash-align FAIL** (line 430): continuation `\` fell at
  column 85 instead of 81. Split the `.irqn` IMP_LV0 initializer onto
  two lines, matching the format used in pwm.c/spi.c.
- **init-has-clock WARN** (line 73): false positive — RP2040 ADC has
  no per-instance clock gate bit (`clk_adc` is configured globally in
  `driver.c clock_configure`). Added a `// no clock gate: ...`
  exemption comment matching the `CLOCK_EXEMPT_RE` regex.

### 2. `source/hal/driver/RaspberryPi/RP2040/dma/dma.c`
- **init-null-isr-no-disable WARN** (line 108): the NVIC enable guard
  only checked `prio != vsf_arch_prio_invalid`, so a user with
  `handler_fn` set but `prio = invalid` would still leave NVIC
  enabled. Now also requires `cfg_ptr->isr.handler_fn != NULL`.

### 3. `document/agent/skills/README.md`
- Reword install instructions to emphasize soft-link (`ln -s` /
  `New-Item -ItemType Junction`) over copy. Multiple projects can
  then share one source of truth and pick up skill updates
  automatically.

## Verification

```
$ python .../quality.py <13 RP2040 driver files>
PASS: 13 file(s) clean
```

All 13 RP2040 driver source files now pass `scripts/check/quality.py`
with 0 errors and 0 warnings.

## Commits

- `7db0ece1f` [hal/driver/rp2040] fix quality.py findings: macro align, NVIC guard, ADC clock exemption
- `1900aeb0d` → amended → `0a5da4e10` [document/skill] README: emphasize symlink-based skill installation