### PR TITLE
[test/vsf_bench] add vsf-bench: automated build, program, test, and debug tool

### DIFF
--- a/document/agent/skills/vsf-bench/SKILL.md
+++ b/document/agent/skills/vsf-bench/SKILL.md
@@ -1,87 +1,100 @@
 ---
 name: vsf-bench
-description: Build, flash, and run automated test suites for VSF firmware on target hardware. Requires board for flash/test; build-only offline. Delegates driver changes to vsf-hal-driver.
+description: Build, program, and test VSF firmware on target hardware. Requires board for program/test; build-only offline. Supports multi-stage pipelines, multi-board parallel test, and capabilities/adapters architecture.
 metadata:
-  version: "1.0"
+  version: "2.0"
   license: Apache-2.0
 ---
 
 **UTILITY SKILL** — used standalone or after vsf-hal-driver changes.
 
 USE FOR:
-- Build-flash-test loop
+- Build-program-test loop
 - Build-only without hardware
-- Flash and test on hardware
+- Program and test on hardware
+- Multi-stage pipelines (bootloader → app → test)
+- Multi-board parallel testing
 
 DO NOT USE FOR:
 - HAL driver porting (use vsf-hal-driver)
 - Driver debugging (use vsf-hal-driver)
-- Modifying test scripts (use write-a-skill)
 
 ## Concepts
 
-- **Orchestrator flow:** `build → flash → for each scene: send trigger → run script`. Trigger is `vsf-test run <scene>` over serial.
-- **Hardware map:** `hardware-map.yml` defines `build.source_dir`, `serial.port`/`baudrate`, `flash.runner` (swd or uf2).
+- **Orchestrator flow:** `build → program → for each suite: send trigger → run script`. Trigger is `vsf-test run <suite>` over serial.
+- **Hardware map:** `hardware-map.yml` defines `build.source_dir`, serial port (descriptive matching by VID/PID/serial), power config, pipelines, and board-level properties (dfu_key, debug_probe).
+- **Program abstraction:** `ProgramCapability` ABC replaces "flash" — DFU, SWD, and UART HCI are all programming methods. The old `FlashRunner` name is preserved as a backward-compat alias.
+- **Pipeline:** Multi-stage build/program/test sequence defined in hardware-map.yml `pipelines:` section. Each stage references a project and can override the runner and flash parameters.
+- **Capabilities/Adapters:** `capabilities/` defines abstract interfaces (ProgramCapability, GPIO). `adapters/` implements them per hardware entity (DFUAdapter, FT232HAdapter). One file per hardware device.
 - **Script signature:** `def run(serial, la=None)`. Scripts validate only — orchestrator sends triggers. Exception = FAIL, normal return = PASS.
 - **Path model:** All paths are cwd-relative or absolute. No `project_root` parameter.
-
-## Testing strategy
-
-**`--all` without `--suite` runs every enabled suite — slow. Only use for final regression.** During development, always limit with `--suite` to the peripheral you're working on. If the firmware is already flashed, `--test` skips build+flash for even faster iteration.
 
 ## Quickstart
 
 ```bash
-# Full regression (build + flash + ALL suites) — SLOW, final gate only
-vsf-bench --all vsf.demo/board/<board>/hardware-map.yml
+# Full regression (build + program + ALL suites) — SLOW, final gate only
+vsf-bench --all --hardware-map board/hardware-map.yml
 
-# Development: build + flash + single suite (fast)
-vsf-bench --all vsf.demo/board/<board>/hardware-map.yml --suite <name>
+# Development: build + program + single suite (fast)
+vsf-bench --all --hardware-map board/hardware-map.yml --suite <name>
 
-# Fastest iteration: test-only, no rebuild (firmware already flashed)
-vsf-bench --test vsf.demo/board/<board>/hardware-map.yml --suite <name>
+# Fastest iteration: test-only, no rebuild (firmware already programmed)
+vsf-bench --test --hardware-map board/hardware-map.yml --suite <name>
 
 # Individual steps (for isolating failures)
-vsf-bench --build  vsf.demo/board/<board>/hardware-map.yml
-vsf-bench --flash  vsf.demo/board/<board>/hardware-map.yml
-vsf-bench --test   vsf.demo/board/<board>/hardware-map.yml
+vsf-bench --build   --hardware-map board/hardware-map.yml
+vsf-bench --program --hardware-map board/hardware-map.yml --board <board>
+vsf-bench --test    --hardware-map board/hardware-map.yml --board <board>
+
+# Pipeline (build + program multiple projects in sequence)
+vsf-bench --pipeline <name> --board <board> --hardware-map board/hardware-map.yml
+
+# Multi-board parallel test
+vsf-bench test --all-boards --project <project> --hardware-map board/hardware-map.yml
+
+# List available pipelines
+vsf-bench --list-pipelines --hardware-map board/hardware-map.yml
 ```
 
-## Example: Full loop after driver changes
+## CLI changes (v2.0)
+
+| Old (v1.x) | New (v2.0) | Reason |
+|-----------|-----------|--------|
+| `--flash` | `--program` | "flash" reserved for flash memory hardware; program covers DFU/SWD/UART |
+| `vsf-bench-flash` | `vsf-bench-program` | Same |
+| `FlashRunner` | `ProgramCapability` (FlashRunner kept as compat alias) | capability abstraction |
+
+## Example: BH1098 pipeline
 
 ```bash
-# Build, flash, and run all test suites:
-vsf-bench --all vsf.demo/board/rp2040/hardware-map.yml
-
-# If build succeeds but flash fails: stop — do not test
-# If flash succeeds but test fails: check logs for timeout, LA, or driver bug
-#   - Timeout/LA → check hardware-map.yml serial/config
-#   - Driver bug → run `Skill("vsf-hal-driver")` with test logs attached
+# Build bootloader (UART) → flash → build app → program via UART
+vsf-bench --pipeline uart_flash_regression --board b1 --hardware-map board/hardware-map.yml
 ```
 
 ## Error handling
 
 | Failure | Cause | Action |
 |---------|-------|--------|
-| Build fails | cmake/SDK missing, wrong `build.source_dir` | verify path and cmake installation |
-| Flash fails | board disconnected, wrong runner | check USB; verify `flash.runner` (swd vs uf2) |
-| Test timeout | baudrate mismatch, firmware not responding | verify `serial.port`/`baudrate` match firmware |
+| Build fails | cmake/IAR/SDK missing, wrong `build.source_dir` | verify path and build tool installation |
+| Program fails | board disconnected, wrong runner, handshake timeout | check USB; verify runner config; check serial port matching |
+| Test timeout | baudrate mismatch, firmware not responding | verify serial port/baudrate match firmware |
 | Suite not found | suite disabled in `vsf_usr_cfg.h` | check `VSF_USE_TEST_<SUITE>` is ENABLED |
-| No scenes listed | test framework not enabled | verify `VSF_USE_TEST = ENABLED` |
-| Hardware unresponsive | USB/connection issue | verify connection and `flash.runner` |
+| No suites listed | test framework not enabled | verify `VSF_USE_TEST = ENABLED` |
+| Hardware unresponsive | USB/connection issue | verify connection and runner config |
+| Multi-device DFU conflict | multiple boards in DFU mode with same VID/PID | power-cycle only target board with DFU key; assign unique serial numbers |
 
-If vsf-bench not installed: `pip install -e vsf.demo/vsf/test/vsf_bench`.
+If vsf-bench not installed: `pip install -e vsf/test/vsf_bench`.
 
 ## Regression failure isolation
 
 When a full `--all` regression fails, **always isolate to a single suite** before blaming the driver:
 
 ```bash
-# 1. Reflash to ensure a clean device state
-vsf-bench --flash vsf.demo/board/<board>/hardware-map.yml
+# 1. Reprogram to ensure a clean device state
+vsf-bench --program --hardware-map board/hardware-map.yml --board <board>
 
 # 2. Run only the failing suite
-vsf-bench --test vsf.demo/board/<board>/hardware-map.yml --suite <failed_suite>
+vsf-bench --test --hardware-map board/hardware-map.yml --board <board> --suite <failed_suite>
 
 # 3. If it passes alone, the failure is caused by suite interaction
 #    (state left behind by a previous suite). Check the suite just before it.
@@ -90,16 +103,9 @@ vsf-bench --test vsf.demo/board/<board>/hardware-map.yml --suite <failed_suite>
 
 **Rule:** a suite that passes in isolation but fails in a full run is NOT a driver bug; it is a test-sequence/state-cleanup bug.
 
-## Limitations
-
-- **Hardware required for flash/test:** `--flash` and `--test` need a connected board. Use `--build` only if no hardware.
-- **Test assumes firmware running:** `--test` alone does not flash first. For cold start, use `--all`.
-- **hardware-map.yml required:** tool cannot infer board config. If missing, copy from `vsf.demo/board/rp2040/hardware-map.yml` as template and edit for your board.
-- **No incremental builds:** always clean-rebuilds.
-
 ## Reference (optional supplementary reading)
 
-- [concepts](modules/concepts.md) — Orchestrator flow, script signature, hardware map, flash runners
-- [examples](modules/examples.md) — IO verification, single scenario
+- [concepts](modules/concepts.md) — Orchestrator flow, script signature, hardware map, capabilities/adapters
+- [examples](modules/examples.md) — IO verification, single scenario, BH1098 pipeline
 - [troubleshooting](modules/troubleshooting.md) — Detailed failure analysis
-- [reference](modules/reference.md) — Complete reference docs
+- [reference](modules/reference.md) — Complete CLI reference

--- a/document/agent/skills/vsf-bench/modules/reference.md
+++ b/document/agent/skills/vsf-bench/modules/reference.md
@@ -25,9 +25,9 @@ vsf-bench --all vsf.demo/board/<board>/ --suite usart_baud --script path/to/cust
 
 # Individual steps
 vsf-bench --build  vsf.demo/board/<board>/
-vsf-bench --flash  vsf.demo/board/<board>/
-vsf-bench --test   vsf.demo/board/<board>/
-vsf-bench --build --flash vsf.demo/board/<board>/
+vsf-bench --program  vsf.demo/board/<board>/
+vsf-bench --test     vsf.demo/board/<board>/
+vsf-bench --build --program vsf.demo/board/<board>/
 vsf-bench --build --test  vsf.demo/board/<board>/
 ```
 

--- a/document/agent/skills/vsf-bench/modules/troubleshooting.md
+++ b/document/agent/skills/vsf-bench/modules/troubleshooting.md
@@ -19,7 +19,7 @@ A suite that fails during `--all` but passes when run alone indicates **state le
 1. Note the first failing suite in the full run (e.g. `pwm_basic`).
 2. Reflash to reset the device:
    ```bash
-   vsf-bench --flash vsf.demo/board/<board>/hardware-map.yml
+   vsf-bench --program vsf.demo/board/<board>/hardware-map.yml
    ```
 3. Run only that suite:
    ```bash

--- a/source/component/usb/device/class/DFU/vsf_usbd_DFU.c
+++ b/source/component/usb/device/class/DFU/vsf_usbd_DFU.c
@@ -150,6 +150,11 @@ static vsf_err_t __vk_usbd_dfu_request_process(vk_usbd_dev_t *dev, vk_usbd_ifs_t
         case DFU_dfuMANIFEST_SYNC:
             dfu->status.bState = DFU_dfuMANIFEST;
             break;
+        case DFU_dfuMANIFEST:
+            /* DFU 1.1 §7: bitManifestationTolerant=0 — manifestation complete,
+               host will issue USB reset to re-enumerate. */
+            dfu->status.bState = DFU_dfuMANIFEST_WAIT_RESET;
+            break;
         }
         break;
     case USB_DFUREQ_CLRSTATUS:

--- a/test/vsf_bench/adapters/dfu.py
+++ b/test/vsf_bench/adapters/dfu.py
@@ -1,0 +1,130 @@
+"""DFUAdapter — DFU flash via dfu-util + optional GPIO for DFU key.
+
+Uses a ``GPIO`` capable adapter (FT232H, CH347, etc.) to hold the DFU key
+during power-on.  Without GPIO, relies on the bootloader auto-entering DFU
+mode when no valid application is present.
+
+Lifecycle (managed by flash_phase context manager)::
+
+    adapter = DFUAdapter(config)
+    with adapter:                  # prepare(): press DFU key via GPIO
+        power_cycle(board)         # board boots with DFU key held → DFU mode
+        adapter.flash(build_dir)   # wait for DFU device → dfu-util → release key
+    # close(): release GPIO
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+from vsf_bench.capabilities.program import ProgramCapability
+from vsf_bench.capabilities.gpio import GPIO
+from vsf_bench.config import RunnerConfig
+
+
+class DFUAdapter(ProgramCapability):
+    """Flash firmware via DFU (Device Firmware Upgrade).
+
+    Required params:
+      * ``vid``: DFU device USB vendor ID (hex)
+      * ``pid``: DFU device USB product ID
+
+    Optional GPIO params (for DFU key):
+      * ``gpio_adapter``: adapter class path (e.g. "vsf_bench.adapters.ft232h.FT232HAdapter")
+      * ``gpio_serial``: FT232H/CH347 USB serial
+      * ``gpio_pin``: pin number (default 0)
+      * ``gpio_active_low``: True if active-low (default True)
+    """
+
+    REQUIRED_PARAMS = ["vid", "pid"]
+
+    def __init__(self, config: RunnerConfig):
+        super().__init__(config)
+        self._vid = int(config.params["vid"], 0)
+        self._pid = int(config.params["pid"], 0)
+        self._gpio = self._create_gpio(config.params)
+
+    @staticmethod
+    def _create_gpio(params: dict) -> GPIO | None:
+        gpio_adapter = params.get("gpio_adapter")
+        if not gpio_adapter:
+            return None
+        # Dynamic import: "vsf_bench.adapters.ft232h.FT232HAdapter"
+        parts = gpio_adapter.rsplit(".", 1)
+        if len(parts) != 2:
+            raise RuntimeError(f"Invalid gpio_adapter: {gpio_adapter}")
+        import importlib
+        mod = importlib.import_module(parts[0])
+        cls = getattr(mod, parts[1])
+        return cls(
+            serial=params["gpio_serial"],
+            pin=int(params.get("gpio_pin", 0)),
+            port=params.get("gpio_port", "AD"),
+            active_low=params.get("gpio_active_low", "true").lower() != "false",
+        )
+
+    # ── DFU key (GPIO) ────────────────────────────────────
+
+    def prepare(self) -> None:
+        if self._gpio:
+            self._gpio.open()
+            self._gpio.set(True)
+
+    def close(self) -> None:
+        if self._gpio:
+            self._gpio.close()
+
+    def _release_key(self) -> None:
+        if self._gpio:
+            self._gpio.set(False)
+
+    # ── DFU flash ─────────────────────────────────────────
+
+    def flash(self, build_dir: Path) -> None:
+        artifact = self._config.artifact
+        if artifact is None:
+            raise RuntimeError("DFUAdapter: no artifact configured")
+
+        dfu_file = build_dir / artifact.name
+        if not dfu_file.exists():
+            raise FileNotFoundError(f"DFU file not found: {dfu_file}")
+
+        if not self._wait_dfu(timeout=10):
+            raise RuntimeError(
+                f"DFU device not found "
+                f"(vid=0x{self._vid:04X} pid=0x{self._pid:04X})"
+            )
+
+        self._release_key()
+        self._dfu_download(str(dfu_file), timeout=120)
+
+    def _wait_dfu(self, timeout: float = 10) -> bool:
+        vid_s = f"{self._vid:04x}"
+        pid_s = f"{self._pid:04x}"
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                result = subprocess.run(
+                    ["dfu-util", "-l", "-d", f"{vid_s}:{pid_s}"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0 and "Found DFU" in result.stdout:
+                    return True
+            except FileNotFoundError:
+                raise RuntimeError("dfu-util not found in PATH")
+            except subprocess.TimeoutExpired:
+                pass
+            time.sleep(0.3)
+        return False
+
+    def _dfu_download(self, dfu_file: str, timeout: float = 120) -> None:
+        vid_s = f"{self._vid:04x}"
+        pid_s = f"{self._pid:04x}"
+        cmd = ["dfu-util", "-d", f"{vid_s}:{pid_s}", "-a", "0", "-D", dfu_file]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"dfu-util failed (exit {result.returncode}): {result.stderr}"
+            )

--- a/test/vsf_bench/adapters/ft232h.py
+++ b/test/vsf_bench/adapters/ft232h.py
@@ -1,0 +1,66 @@
+"""FT232HAdapter — GPIO via FT232H MPSSE mode (pyftdi).
+
+Also supports I2C/SPI via the same chip (future).
+"""
+
+from vsf_bench.capabilities.gpio import GPIO
+
+try:
+    from pyftdi.ftdi import Ftdi
+except ImportError:
+    Ftdi = None
+
+
+class FT232HAdapter(GPIO):
+    """Control an FT232H pin as GPIO output.
+
+    Parameters:
+        serial: FT232H USB serial number (e.g. "FT96OF9L").
+        pin: pin number (0-7).
+        port: "AD" for ADBUS, "AC" for ACBUS (default "AD").
+        active_low: True if the logical "active" state is low (default True).
+    """
+
+    # MPSSE command bytes for each port
+    _CMD = {"AD": 0x80, "AC": 0x82}
+
+    def __init__(self, serial: str, pin: int = 0, port: str = "AD",
+                 active_low: bool = True):
+        if Ftdi is None:
+            raise RuntimeError("pyftdi not installed. Run: pip install pyftdi")
+        if port not in self._CMD:
+            raise ValueError(f"port must be 'AD' or 'AC', got {port!r}")
+        self._serial = serial
+        self._pin = pin
+        self._port = port
+        self._cmd = self._CMD[port]
+        self._active_low = active_low
+        self._ftdi = None
+        self._value = 0xFF
+
+    def open(self) -> None:
+        self._ftdi = Ftdi()
+        self._ftdi.open_mpsse_from_url(
+            f"ftdi://ftdi:232h:{self._serial}/1",
+            direction=0xFF,  # all output
+        )
+        self._value = 0xFF
+
+    def close(self) -> None:
+        if self._ftdi:
+            try:
+                self.set(False)
+                self._ftdi.write_data(bytes([self._cmd, 0xFF, 0xFF]))
+                self._ftdi.close()
+            except Exception:
+                pass
+            self._ftdi = None
+
+    def set(self, active: bool) -> None:
+        """Set pin to active (taking active_low into account)."""
+        high = not active if self._active_low else active
+        if high:
+            self._value |= (1 << self._pin)
+        else:
+            self._value &= ~(1 << self._pin)
+        self._ftdi.write_data(bytes([self._cmd, self._value, 0xFF]))

--- a/test/vsf_bench/builders/iar_builder.py
+++ b/test/vsf_bench/builders/iar_builder.py
@@ -1,0 +1,123 @@
+"""IAR Embedded Workbench builder — directly calls IarBuild.exe.
+
+No external script dependency. Locates IarBuild.exe via:
+1. ``IAR_EWARM_DIR`` environment variable
+2. Default install path: ``C:/iar/ewarm-*.*.*/common/bin/IarBuild.exe``
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from vsf_bench.builders.base import BuildRunner
+
+
+def _find_iarbuild() -> str:
+    """Locate IarBuild.exe. Raises FileNotFoundError if not found."""
+    # 1. Environment variable
+    env_dir = os.environ.get("IAR_EWARM_DIR")
+    if env_dir:
+        candidate = Path(env_dir) / "common" / "bin" / "IarBuild.exe"
+        if candidate.exists():
+            return str(candidate)
+
+    # 2. shutil.which (PATH lookup)
+    which = shutil.which("IarBuild.exe")
+    if which:
+        return which
+
+    # 3. Search IAR install roots across all drives and known patterns
+    search_roots = _collect_iar_roots()
+    for root in search_roots:
+        candidate = root / "common" / "bin" / "IarBuild.exe"
+        if candidate.exists():
+            return str(candidate)
+
+    raise FileNotFoundError(
+        "IarBuild.exe not found. Set IAR_EWARM_DIR environment variable "
+        "to your IAR EWARM installation root."
+    )
+
+
+def _collect_iar_roots() -> list[Path]:
+    """Collect candidate IAR EWARM install directories."""
+    roots: list[Path] = []
+
+    # Common base directories
+    progfiles_x86 = os.environ.get("ProgramFiles(x86)", "C:/Program Files (x86)")
+    progfiles = os.environ.get("ProgramFiles", "C:/Program Files")
+
+    base_dirs = [
+        Path(progfiles_x86) / "IAR Systems",
+        Path(progfiles) / "IAR Systems",
+        Path("C:/iar"),
+        Path("/c/iar"),
+    ]
+
+    # Also try other drive roots (D:, E:)
+    import string
+    for drive in string.ascii_uppercase[3:6]:  # D, E, F
+        for pf in ("Program Files (x86)", "Program Files"):
+            p = Path(f"{drive}:/{pf}/IAR Systems")
+            if p.exists():
+                base_dirs.append(p)
+
+    for base in base_dirs:
+        if not base.exists():
+            continue
+        # Pattern 1: ewarm-* (e.g. C:/iar/ewarm-9.60.3)
+        for name in ("ewarm-*", "arm-*"):
+            for d in sorted(base.glob(name), reverse=True):
+                if (d / "common" / "bin" / "IarBuild.exe").exists():
+                    roots.append(d)
+                    break  # newest first
+
+        # Pattern 2: Embedded Workbench * (e.g. Embedded Workbench 8.3)
+        for d in sorted(base.glob("Embedded Workbench *"), reverse=True):
+            arm_dir = d / "arm"
+            if arm_dir.exists():
+                roots.append(arm_dir)
+            else:
+                roots.append(d)
+
+    return roots
+
+
+class IARBuilder(BuildRunner):
+    """Build an IAR .ewp project directly via IarBuild.exe."""
+
+    def __init__(self, build_cfg):
+        self._build_cfg = build_cfg
+
+    def build(self) -> Path:
+        cfg = self._build_cfg
+        source_dir = Path(cfg.source_dir)
+        build_dir = Path(cfg.build_dir)
+        params = cfg.params
+
+        ewp_file = params.get("project")
+        if not ewp_file:
+            raise RuntimeError("IARBuilder: missing 'project' param (ewp filename)")
+
+        config = params.get("config", "")
+        if not config:
+            raise RuntimeError("IARBuilder: missing 'config' param")
+
+        ewp_path = source_dir / ewp_file
+        if not ewp_path.exists():
+            raise FileNotFoundError(f"IARBuilder: .ewp not found: {ewp_path}")
+
+        iarbuild = _find_iarbuild()
+        jobs = os.cpu_count() or 8
+
+        cmd = [iarbuild, str(ewp_path), "-make", config, "-parallel", str(jobs)]
+        print(f"[vsf-bench] IAR: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=False, cwd=str(source_dir))
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"IAR build failed (exit {result.returncode})"
+            )
+
+        return build_dir

--- a/test/vsf_bench/builders/registry.py
+++ b/test/vsf_bench/builders/registry.py
@@ -5,9 +5,11 @@ import from here. Add new built-in builders here.
 """
 
 from vsf_bench.builders.cmake_builder import CMakeBuilder
+from vsf_bench.builders.iar_builder import IARBuilder
 
 BUILDER_TYPES: dict[str, type] = {
     "cmake": CMakeBuilder,
+    "iar": IARBuilder,
 }
 
 

--- a/test/vsf_bench/capabilities/gpio.py
+++ b/test/vsf_bench/capabilities/gpio.py
@@ -1,0 +1,28 @@
+"""GPIO — abstract capability for digital I/O pin control."""
+
+from abc import ABC, abstractmethod
+
+
+class GPIO(ABC):
+    """Control a single GPIO pin (high/low).
+
+    Adapters: FT232H, CH347, Raspberry Pi GPIO, etc.
+    """
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def open(self) -> None:
+        """Initialise the GPIO hardware."""
+
+    def close(self) -> None:
+        """Release the GPIO hardware."""
+
+    @abstractmethod
+    def set(self, high: bool) -> None:
+        """Set the output level of the pin (True = high, False = low)."""
+        ...

--- a/test/vsf_bench/capabilities/program.py
+++ b/test/vsf_bench/capabilities/program.py
@@ -1,0 +1,47 @@
+"""ProgramCapability — abstract interface for any adapter that can program firmware."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from vsf_bench.config import RunnerConfig
+
+
+class ProgramCapability(ABC):
+    """A hardware capability to program firmware to a target device.
+
+    Subclasses implement the programming protocol (UART HCI, DFU, SWD, etc.).
+    The caller (program_phase) follows this lifecycle::
+
+        adapter = DFUAdapter(config)
+        with adapter:                    # → prepare(), open resources
+            power_cycle(board)
+            adapter.flash(build_dir)     # → handshake / wait / download
+        # → close(), release resources
+    """
+
+    REQUIRED_PARAMS: list[str] = []
+
+    def __init__(self, config: RunnerConfig):
+        self._config = config
+
+    def __enter__(self):
+        self.prepare()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def prepare(self) -> None:
+        """Optional hook before power-on (open serial, press DFU key, etc.)."""
+
+    def close(self) -> None:
+        """Optional hook to release resources (close serial, release GPIO)."""
+
+    @abstractmethod
+    def flash(self, build_dir: Path) -> None:
+        """Program firmware to the target device."""
+        ...
+
+    @classmethod
+    def validate_params(cls, params: dict) -> list[str]:
+        return []

--- a/test/vsf_bench/capture_marker.py
+++ b/test/vsf_bench/capture_marker.py
@@ -91,6 +91,7 @@ def read_framework_windows(
     decode_start_ns: int | None = None,
     decode_end_ns: int | None = None,
     marker_baud: int = 115200,
+    marker_channel: str = "uart0_tx",  # configurable per-board via logic_analyzer config
 ) -> list[CaseWindow]:
     """Per-case windows for both TX and RX scenarios.
 
@@ -98,11 +99,11 @@ def read_framework_windows(
     READY → DONE. Otherwise, windows are bounded by CASE:N → CASE:N+1
     (or END for the last case).
 
-    The marker channel (uart0_tx) is decoded **once per unique capture
-    window** and cached in memory, so calling this function for many
-    suites in a shared-LA run only incurs a single dsview-cli invocation.
+    *marker_channel* can be configured per-board via hardware-map.yml
+    ``logic_analyzer.marker_channel``.  Decoded once per unique capture
+    window and cached.
     """
-    ch = la.channel("uart0_tx")
+    ch = la.channel(marker_channel)
     text, timestamps = _read_marker_channel(
         la, ch, marker_baud, decode_start_ns, decode_end_ns
     )

--- a/test/vsf_bench/cli/__init__.py
+++ b/test/vsf_bench/cli/__init__.py
@@ -1,9 +1,9 @@
 """CLI entry points for vsf-bench.
 
-* `cli.run`   — vsf-bench (unified build/flash/test pipeline)
-* `cli.build` — vsf-bench-build (standalone build)
-* `cli.flash` — vsf-bench-flash (standalone flash)
-* `cli.test`  — vsf-bench-test (standalone test, assumes firmware already running)
+* `cli.run`     — vsf-bench (unified build/program/test pipeline)
+* `cli.build`   — vsf-bench-build (standalone build)
+* `cli.program`  — vsf-bench-program (standalone program)
+* `cli.test`    — vsf-bench-test (standalone test, assumes firmware already running)
 
 The standalone scripts and the unified pipeline share their phase logic
 through `vsf_bench.pipeline` and `vsf_bench.suite` modules — there is one

--- a/test/vsf_bench/cli/_args.py
+++ b/test/vsf_bench/cli/_args.py
@@ -49,9 +49,20 @@ def add_shared_test_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--board",
+        action="append",
+        default=None,
+        help="Select target board(s) by name. Repeat for multiple boards, or use --all-boards",
+    )
+    parser.add_argument(
+        "--all-boards",
+        action="store_true",
+        help="Run on all connected boards (from hardware-map.yml)",
+    )
+    parser.add_argument(
+        "--project",
         type=str,
         default=None,
-        help="Select target board by name (or serial port) when multiple are connected",
+        help="Select project by name from hardware-map.yml projects section",
     )
     parser.add_argument(
         "--wait",
@@ -61,7 +72,13 @@ def add_shared_test_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Wait for board lock if busy (optional timeout in seconds)",
     )
-    parser.add_argument("board_dir")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate test_params.yml schema only, do not execute tests",
+    )
+    parser.add_argument("--hardware-map", type=str, required=True,
+                        help="Path to hardware-map.yml")
 
 
 def resolve_shuffle_seed(args, case_specs: list[str]) -> int | None:

--- a/test/vsf_bench/cli/build.py
+++ b/test/vsf_bench/cli/build.py
@@ -25,10 +25,11 @@ def main():
     parser.add_argument("board_dir")
     args = parser.parse_args()
 
-    hardware_map_path = Path(args.board_dir) / "hardware-map.yml"
+    hardware_map_path = Path(args.hardware_map)
 
     try:
-        board = pipeline.load_board(hardware_map_path, board_name=args.board)
+        board_name = args.board[0] if args.board else None
+        board = pipeline.load_board(hardware_map_path, board_name=board_name)
     except Exception as e:
         print(f"[vsf-bench-build] Config error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/test/vsf_bench/cli/debug.py
+++ b/test/vsf_bench/cli/debug.py
@@ -1,0 +1,141 @@
+"""vsf-bench-debug — pyOCD crash dump and backtrace.
+
+Usage::
+
+    vsf-bench-debug crash-dump --board b1 <board_dir>
+    vsf-bench-debug backtrace --board b1 <board_dir>
+    vsf-bench-debug regs --board b1 <board_dir>
+    vsf-bench-debug read --board b1 --addr 0x2000FF00 --len 256 <board_dir>
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from vsf_bench.hardware_map import load as load_hardware_map
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog="vsf-bench-debug")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("crash-dump", help="Halt CPU, capture crash context, resume")
+    sub.add_parser("backtrace", help="Halt CPU, read current call stack")
+    sub.add_parser("regs", help="Halt CPU, read R0-R12/SP/LR/PC/xPSR")
+
+    read_p = sub.add_parser("read", help="Read memory block")
+    read_p.add_argument("--addr", type=str, required=True, help="Start address (hex)")
+    read_p.add_argument("--len", type=int, default=256, help="Length in bytes")
+
+    parser.add_argument("--board", type=str, default=None)
+    parser.add_argument("board_dir")
+    return parser.parse_args()
+
+
+def _resolve_board(hardware_map_path: str, board_name: str | None):
+    board = load_hardware_map(hardware_map_path, board_name=board_name)
+    if board.debug_probe is None:
+        print(
+            "[vsf-bench-debug] Error: board has no debug_probe in hardware-map.yml",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return board
+
+
+def cmd_crash_dump(board, args):
+    """Halt CPU, capture crash context, output JSON."""
+    from vsf_bench.debug import DebugSession
+
+    probe_cfg = board.debug_probe
+    target = probe_cfg.get("target", "cortex_m")
+    probe_id = probe_cfg.get("probe")
+
+    with DebugSession(target=target, probe=probe_id) as dbg:
+        dump = dbg.crash_dump()
+    print(dump.to_json())
+
+
+def cmd_backtrace(board, args):
+    """Halt CPU, read current call stack."""
+    from vsf_bench.debug import DebugSession
+
+    probe_cfg = board.debug_probe
+    target = probe_cfg.get("target", "cortex_m")
+
+    with DebugSession(target=target) as dbg:
+        dbg.halt()
+        try:
+            frames = dbg.stack_backtrace()
+            print(f"PC = 0x{frames[0].pc:08X}")
+            print(f"SP = 0x{frames[0].sp:08X}")
+            print(f"LR = 0x{frames[0].lr:08X}")
+        finally:
+            dbg.resume()
+
+
+def cmd_regs(board, args):
+    """Halt CPU, dump all core registers."""
+    from vsf_bench.debug import DebugSession
+
+    probe_cfg = board.debug_probe
+    target = probe_cfg.get("target", "cortex_m")
+
+    with DebugSession(target=target) as dbg:
+        dbg.halt()
+        try:
+            regs = dbg.read_core_regs()
+            for name in ["R0", "R1", "R2", "R3", "R4", "R5", "R6", "R7",
+                         "R8", "R9", "R10", "R11", "R12", "SP", "LR", "PC", "XPSR"]:
+                print(f"  {name:4s} = 0x{regs[name]:08X}")
+        finally:
+            dbg.resume()
+
+
+def cmd_read(board, args):
+    """Read a memory block."""
+    from vsf_bench.debug import DebugSession
+
+    addr = int(args.addr, 0)
+    length = args.len
+
+    probe_cfg = board.debug_probe
+    target = probe_cfg.get("target", "cortex_m")
+
+    with DebugSession(target=target) as dbg:
+        data = dbg.read_mem(addr, length)
+    for i in range(0, len(data), 16):
+        chunk = data[i:i + 16]
+        hex_str = " ".join(f"{b:02X}" for b in chunk)
+        print(f"  0x{addr + i:08X}: {hex_str}")
+
+
+def main():
+    args = parse_args()
+
+    hardware_map_path = Path(args.hardware_map).resolve()
+    try:
+        board = _resolve_board(str(hardware_map_path), args.board)
+    except Exception as e:
+        print(f"[vsf-bench-debug] Config error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    handlers = {
+        "crash-dump": cmd_crash_dump,
+        "backtrace": cmd_backtrace,
+        "regs": cmd_regs,
+        "read": cmd_read,
+    }
+    try:
+        handlers[args.cmd](board, args)
+    except ImportError as e:
+        print(f"[vsf-bench-debug] Import error: {e}", file=sys.stderr)
+        sys.exit(3)
+    except Exception as e:
+        print(f"[vsf-bench-debug] Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vsf_bench/cli/program.py
+++ b/test/vsf_bench/cli/program.py
@@ -1,4 +1,4 @@
-"""vsf-bench-flash — standalone flash entry point.
+"""vsf-bench-program — standalone flash entry point.
 
 Flashes the artifact produced by a prior build to the board via the
 active runner declared in hardware-map.yml.
@@ -20,34 +20,35 @@ from vsf_bench.lock import LockBusyError
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="vsf-bench-flash")
+    parser = argparse.ArgumentParser(prog="vsf-bench-program")
     add_shared_test_args(parser)
     args = parser.parse_args()
 
-    hardware_map_path = Path(args.board_dir) / "hardware-map.yml"
+    hardware_map_path = Path(args.hardware_map)
 
     try:
-        board = pipeline.load_board(hardware_map_path, board_name=args.board)
+        board_name = args.board[0] if args.board else None
+        board = pipeline.load_board(hardware_map_path, board_name=board_name)
     except Exception as e:
-        print(f"[vsf-bench-flash] Config error: {e}", file=sys.stderr)
+        print(f"[vsf-bench-program] Config error: {e}", file=sys.stderr)
         sys.exit(2)
 
     build_dir = Path(board.build.build_dir)
     if not build_dir.exists():
-        print(f"[vsf-bench-flash] Build directory missing: {build_dir}", file=sys.stderr)
-        print(f"[vsf-bench-flash] Run vsf-bench-build first.", file=sys.stderr)
+        print(f"[vsf-bench-program] Build directory missing: {build_dir}", file=sys.stderr)
+        print(f"[vsf-bench-program] Run vsf-bench-build first.", file=sys.stderr)
         sys.exit(2)
 
     try:
         lock = pipeline.acquire_board_lock(board, args.wait)
     except LockBusyError as e:
-        print(f"[vsf-bench-flash] {e}", file=sys.stderr)
+        print(f"[vsf-bench-program] {e}", file=sys.stderr)
         sys.exit(3)
 
     try:
-        pipeline.flash_phase(board, build_dir)
+        pipeline.program_phase(board, build_dir)
     except Exception as e:
-        print(f"[vsf-bench-flash] Flash failed: {e}", file=sys.stderr)
+        print(f"[vsf-bench-program] Program failed: {e}", file=sys.stderr)
         sys.exit(1)
     finally:
         if lock is not None:

--- a/test/vsf_bench/cli/run.py
+++ b/test/vsf_bench/cli/run.py
@@ -1,6 +1,6 @@
 """vsf-bench — unified build / flash / test pipeline.
 
-Composes `pipeline.build_phase`, `pipeline.flash_phase`, and
+Composes `pipeline.build_phase`, `pipeline.program_phase`, and
 `pipeline.run_test_phase` based on the requested flags. Standalone
 scripts (`vsf-bench-build`, `vsf-bench-flash`, `vsf-bench-test`) call
 the same underlying functions, so behavior stays consistent.
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from vsf_bench import pipeline
 from vsf_bench.cli._args import add_shared_test_args, resolve_shuffle_seed
+from vsf_bench.hwctrl.tee_logger import init_logger as _init_logger
 from vsf_bench.lock import LockBusyError
 
 
@@ -25,51 +26,134 @@ def parse_args():
     parser = argparse.ArgumentParser(prog="vsf-bench")
     add_shared_test_args(parser)
     parser.add_argument("--build", action="store_true")
-    parser.add_argument("--flash", action="store_true")
+    parser.add_argument("--program", action="store_true")
     parser.add_argument("--test", action="store_true")
     parser.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--pipeline", type=str, default=None,
+        help="Run a named multi-stage pipeline (from hardware-map.yml pipelines section)",
+    )
+    parser.add_argument(
+        "--list-pipelines", action="store_true",
+        help="List available pipelines in hardware-map.yml",
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
+    # Load hardware-map defaults (log_dir etc.)
+    hw_path = Path(args.hardware_map).resolve()
+    from vsf_bench.hardware_map import load_defaults
+    _defaults = load_defaults(str(hw_path)) if hw_path.exists() else {}
+    log_dir = args.log_dir or _defaults.get("log_dir")
+
+    # ── --list-pipelines ──
+    if args.list_pipelines:
+        from vsf_bench.hardware_map import list_pipelines as _list_pipelines
+        try:
+            pipelines = _list_pipelines(str(hw_path))
+        except Exception as e:
+            print(f"[vsf-bench] Error: {e}", file=sys.stderr)
+            sys.exit(2)
+        if not pipelines:
+            print("No pipelines defined in hardware-map.yml")
+        else:
+            print("Available pipelines:")
+            for p in pipelines:
+                desc = f" — {p.description}" if p.description else ""
+                print(f"  {p.name}{desc}")
+        return
+
+    # ── --pipeline ──
+    if args.pipeline:
+        if not args.board:
+            print("[vsf-bench] Error: --pipeline requires --board", file=sys.stderr)
+            sys.exit(2)
+        from vsf_bench.hardware_map import load_pipeline, resolve_pipeline_projects
+        board_name = args.board[0] if args.board else None
+        try:
+            pipeline_obj = load_pipeline(str(hw_path), args.pipeline)
+            board, _first_project = pipeline.load_board(
+                hw_path,
+                board_name=board_name,
+                project_name=pipeline_obj.stages[0].project,
+            )
+            project_map = resolve_pipeline_projects(
+                pipeline_obj, str(hw_path), board_name=board_name,
+            )
+            _init_logger(log_dir)
+        except Exception as e:
+            print(f"[vsf-bench] Pipeline error: {e}", file=sys.stderr)
+            sys.exit(2)
+        try:
+            pipeline.run_pipeline(pipeline_obj, board, project_map)
+        except Exception as e:
+            print(f"[vsf-bench] Pipeline failed: {e}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    # Initialize TeeLogger — use --log-dir, or hardware-map defaults.log_dir
+    _init_logger(log_dir)
+
+    hardware_map_path = Path(args.hardware_map).resolve()
     do_build = args.build or args.all
-    do_flash = args.flash or args.all
+    do_program = args.program or args.all
     do_test = args.test or args.all
 
-    if not (do_build or do_flash or do_test):
-        print("[vsf-bench] Error: at least one of --build, --flash, --test, --all is required")
+    if not args.project:
+        print("[vsf-bench] Error: --project is required", file=sys.stderr)
         sys.exit(2)
 
-    hardware_map_path = (Path(args.board_dir) / "hardware-map.yml").resolve()
-    test_params_yml = hardware_map_path.parent / "test_params.yml"
-    if not test_params_yml.exists():
-        test_params_yml = None
+    # Load project
+    from vsf_bench.hardware_map import load_project as _load_project
     try:
-        board = pipeline.load_board(hardware_map_path, board_name=args.board)
+        project = _load_project(str(hardware_map_path), args.project)
     except Exception as e:
         print(f"[vsf-bench] Config error: {e}", file=sys.stderr)
         sys.exit(2)
 
+    # Load board (only needed for program/test)
+    board = None
+    if do_program or do_test:
+        try:
+            _board_result = pipeline.load_board(
+                hardware_map_path,
+                project_name=args.project,
+                board_name=(args.board[0] if args.board else None),
+            )
+            # load_board returns (board, project) tuple when project_name is given
+            board = _board_result[0] if isinstance(_board_result, tuple) else _board_result
+        except Exception as e:
+            print(f"[vsf-bench] Config error: {e}", file=sys.stderr)
+            sys.exit(2)
+        for _rcfg in project.runners.values():
+            p = _rcfg.params
+            p.setdefault("program_port", board.program_uart)
+            p.setdefault("debug_port", board.debug_uart)
+            p.setdefault("debug_baudrate", board.debug_baudrate)
+
+    build_config = project.build
+
     # Apply CLI overrides for source/build directories
     if args.source_dir:
-        board.build.source_dir = args.source_dir
+        build_config.source_dir = args.source_dir
         if not args.build_dir:
-            board.build.build_dir = str(Path(args.source_dir) / "build")
+            build_config.build_dir = str(Path(args.source_dir) / "build")
     if args.build_dir:
-        board.build.build_dir = args.build_dir
+        build_config.build_dir = args.build_dir
 
-    build_dir = Path(board.build.build_dir)
+    build_dir = Path(build_config.build_dir)
 
     if do_build:
         try:
-            build_dir = pipeline.build_phase(board)
+            build_dir = pipeline.build_phase(project)
         except Exception as e:
             print(f"[vsf-bench] Build failed: {e}", file=sys.stderr)
             sys.exit(1)
 
-    if do_flash or do_test:
+    if do_program or do_test:
         try:
             lock = pipeline.acquire_board_lock(board, args.wait)
         except LockBusyError as e:
@@ -79,15 +163,15 @@ def main():
         lock = None
 
     try:
-        if do_flash:
+        if do_program:
             if not build_dir.exists():
                 print(f"[vsf-bench] Build directory missing: {build_dir}", file=sys.stderr)
                 print(f"[vsf-bench] Run with --build first.", file=sys.stderr)
                 sys.exit(2)
             try:
-                pipeline.flash_phase(board, build_dir)
+                pipeline.program_phase(board, build_dir, project=project)
             except Exception as e:
-                print(f"[vsf-bench] Flash failed: {e}", file=sys.stderr)
+                print(f"[vsf-bench] Program failed: {e}", file=sys.stderr)
                 sys.exit(1)
 
         if not do_test:

--- a/test/vsf_bench/cli/test.py
+++ b/test/vsf_bench/cli/test.py
@@ -28,13 +28,37 @@ def parse_args():
 
 def main():
     args = parse_args()
-    hardware_map_path = (Path(args.board_dir) / "hardware-map.yml").resolve()
+    hardware_map_path = Path(args.hardware_map).resolve()
+
+    # ── Multi-board / --all-boards ──
+    if args.all_boards:
+        if not args.project:
+            print("[vsf-bench-test] Error: --all-boards requires --project", file=sys.stderr)
+            sys.exit(2)
+        try:
+            results = pipeline.run_test_phase_all(
+                hardware_map_path=str(hardware_map_path),
+                project_name=args.project,
+                suite_names=args.suite,
+                la_mode=args.la_mode,
+                log_dir=args.log_dir,
+                trace_level=args.trace_level,
+            )
+        except Exception as e:
+            print(f"[vsf-bench-test] Multi-board error: {e}", file=sys.stderr)
+            sys.exit(1)
+        if not all(results.values()):
+            sys.exit(1)
+        return
+
+    # ── Single board ──
+    board_name = args.board[0] if args.board else None
     test_params_yml = hardware_map_path.parent / "test_params.yml"
     if not test_params_yml.exists():
         test_params_yml = None
 
     try:
-        board = pipeline.load_board(hardware_map_path, board_name=args.board)
+        board = pipeline.load_board(hardware_map_path, board_name=board_name)
     except Exception as e:
         print(f"[vsf-bench-test] Config error: {e}", file=sys.stderr)
         sys.exit(2)

--- a/test/vsf_bench/config.py
+++ b/test/vsf_bench/config.py
@@ -2,9 +2,25 @@
 
 Separated from hardware_map.py to avoid circular imports between
 hardware_map, runners, and registry.
+
+Board/Project separation: BoardConfig describes a physical board (serial
+port, baud, power, fixtures).  ProjectConfig describes what firmware to
+build and how to flash it (build tool, runner, artifacts).  One board can
+run multiple projects.
 """
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class TestResult(str, Enum):
+    """Precise test verdict."""
+    PASS = "PASS"
+    FAIL_TIMEOUT = "FAIL_TIMEOUT"
+    FAIL_ASSERT = "FAIL_ASSERT"
+    FAIL_CRASH = "FAIL_CRASH"
+    FAIL_DECODE = "FAIL_DECODE"
+    SKIP = "SKIP"
 
 
 @dataclass
@@ -21,17 +37,11 @@ class RunnerConfig:
 
 
 @dataclass
-class BuilderConfig:
-    type: str
-    params: dict = field(default_factory=dict)
-
-
-@dataclass
 class BuildConfig:
     source_dir: str
     build_dir: str
-    build_tool: str = "cmake"
-    builders: dict[str, BuilderConfig] = field(default_factory=dict)
+    tool: str = "cmake"                       # builder name → registry lookup
+    params: dict = field(default_factory=dict)  # builder-specific parameters
     artifacts: list[ArtifactConfig] = field(default_factory=list)
 
 
@@ -42,36 +52,19 @@ class LogicAnalyzerConfig:
     samplerate: str = "10M"
     capture_duration: float = 120.0
     channels: dict[str, str] = field(default_factory=dict)
+    marker_channel: str | None = None  # per-board marker UART channel; None falls back to caller default
 
 
 @dataclass
-class BoardConfig:
-    platform: str
-    active_runner: str
-    runners: dict[str, RunnerConfig]
-    serial: str
-    baud: int
+class ProjectConfig:
+    """Firmware project: build, artifacts, and how to flash."""
     build: BuildConfig
-    connected: bool = True
-    fixtures: list[str] = field(default_factory=list)
-    logic_analyzer: LogicAnalyzerConfig | None = None
-    board_pins: str = ""
+    active_runner: str = ""
+    runners: dict[str, RunnerConfig] = field(default_factory=dict)
     name: str = ""
 
     def validate(self) -> None:
         missing = []
-        if not self.platform:
-            missing.append("platform")
-        if not self.active_runner:
-            missing.append("active_runner")
-        if self.active_runner not in self.runners:
-            missing.append(f"runners.{self.active_runner} (active runner not in runners map)")
-        if not self.runners:
-            missing.append("runners")
-        if not self.serial:
-            missing.append("serial")
-        if not self.baud:
-            missing.append("baud")
         if not self.build.source_dir:
             missing.append("build.source_dir")
         if not self.build.build_dir:
@@ -79,4 +72,60 @@ class BoardConfig:
         if not self.build.artifacts:
             missing.append("build.artifacts")
         if missing:
-            raise ValueError(f"Missing required fields: {', '.join(missing)}")
+            raise ValueError(f"ProjectConfig missing: {', '.join(missing)}")
+
+
+@dataclass
+class StageConfig:
+    """One stage in a multi-project pipeline.
+
+    Each stage references a project and specifies which actions to run.
+    ``flash_overrides`` can override runner, artifact, or params per-stage.
+    ``wait_for`` specifies a regex to match in serial log after flash.
+    """
+    project: str                          # project name (resolved later)
+    actions: list[str]                    # "build" / "flash" / "test"
+    flash_overrides: dict | None = None   # e.g. {"runner": "dfu", "artifact": {...}}
+    wait_for: str | None = None           # log pattern to wait for after flash
+    power_cycle: bool = False             # power-cycle before this stage
+
+
+@dataclass
+class PipelineConfig:
+    """Multi-stage pipeline: named sequence of build/flash/test stages."""
+    name: str
+    description: str = ""
+    stages: list[StageConfig] = field(default_factory=list)
+
+
+@dataclass
+class PowerConfig:
+    type: str = "smartusbhub"
+    hub_addr: int | None = None
+    port: int = 3
+
+
+@dataclass
+class BoardConfig:
+    platform: str
+    debug_uart: str = ""          # log UART COM port (resolved)
+    debug_baudrate: int = 0
+    program_uart: str = ""     # download/flash UART COM port (resolved)
+    connected: bool = True
+    power: PowerConfig | None = None
+    fixtures: list[str] = field(default_factory=list)
+    logic_analyzer: LogicAnalyzerConfig | None = None
+    debug_probe: dict | None = None
+    dfu_key: dict | None = None    # {gpio, pin, active_low}
+    gpio_adapter_serial: str = ""  # resolved from gpio_adapters section
+    board_pins: str = ""
+    name: str = ""
+
+    def validate(self) -> None:
+        missing = []
+        if not self.platform:
+            missing.append("platform")
+        if not self.debug_uart:
+            missing.append("debug_uart")
+        if missing:
+            raise ValueError(f"BoardConfig missing: {', '.join(missing)}")

--- a/test/vsf_bench/debug.py
+++ b/test/vsf_bench/debug.py
@@ -1,0 +1,261 @@
+"""Debug module — pyOCD-based crash dump and backtrace for BH1098.
+
+Provides ``DebugSession`` for script-driven exception analysis
+without GDB interaction.  AI-friendly: pure Python, no interactive prompts.
+
+Hardware requirement: CMSIS-DAP or J-Link probe connected to board SWD pins.
+
+Usage::
+
+    from vsf_bench.debug import DebugSession
+
+    with DebugSession("cortex_m") as dbg:
+        dump = dbg.crash_dump()
+        print(f"Fault: {dump.fault_type}  PC: 0x{dump.pc:08X}")
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StackFrame:
+    """One frame in a stack backtrace."""
+    pc: int
+    sp: int = 0
+    lr: int = 0
+    function: str = ""
+    file: str = ""
+    line: int = 0
+
+    def to_dict(self) -> dict:
+        d = {"pc": f"0x{self.pc:08X}"}
+        if self.sp:
+            d["sp"] = f"0x{self.sp:08X}"
+        if self.lr:
+            d["lr"] = f"0x{self.lr:08X}"
+        if self.function:
+            d["function"] = self.function
+        if self.file:
+            d["file"] = self.file
+        if self.line:
+            d["line"] = self.line
+        return d
+
+
+@dataclass
+class CrashDump:
+    """Full crash context: fault classification, registers, stack backtrace."""
+    fault_type: str = ""
+    pc: int = 0
+    sp: int = 0
+    lr: int = 0
+    cfsr: int = 0
+    hfsr: int = 0
+    mmfar: int = 0
+    bfar: int = 0
+    core_regs: dict[str, int] = field(default_factory=dict)
+    stack: list[StackFrame] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "fault": self.fault_type,
+            "pc": f"0x{self.pc:08X}",
+            "sp": f"0x{self.sp:08X}",
+            "lr": f"0x{self.lr:08X}",
+            "cfsr": f"0x{self.cfsr:08X}",
+            "hfsr": f"0x{self.hfsr:08X}",
+            "mmfar": f"0x{self.mmfar:08X}",
+            "bfar": f"0x{self.bfar:08X}",
+            "regs": {k: f"0x{v:08X}" for k, v in self.core_regs.items()},
+            "stack": [f.to_dict() for f in self.stack],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+class DebugSession:
+    """pyOCD debug session for BH1098 (Cortex-M4F).
+
+    Thin wrapper around pyOCD session.  Does NOT flash or erase — this is
+    a read-only debug tool for crash analysis and memory inspection.
+
+    Parameters:
+        target: pyOCD target name (default ``"cortex_m"`` for BH1098H M4F).
+        probe: optional probe unique ID to disambiguate multiple probes.
+    """
+
+    # SCB fault register offsets from 0xE000ED00
+    _SCB_BASE = 0xE000ED00
+    _CFSR_OFF  = 0x28   # Configurable Fault Status Register
+    _HFSR_OFF  = 0x2C   # HardFault Status Register
+    _MMFAR_OFF = 0x34   # MemManage Fault Address Register
+    _BFAR_OFF  = 0x38   # BusFault Address Register
+
+    _CORE_REG_NAMES = [f"r{i}" for i in range(13)] + ["sp", "lr", "pc", "xpsr"]
+
+    def __init__(self, target: str = "cortex_m", probe: str | None = None):
+        self._target_name = target
+        self._probe = probe
+        self._session = None
+
+    # ── context manager ────────────────────────────────────
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *args):
+        self.disconnect()
+        return False
+
+    # ── connection lifecycle ───────────────────────────────
+
+    def connect(self):
+        """Open pyOCD session.  Raises RuntimeError if pyOCD unavailable."""
+        try:
+            from pyocd.core.helpers import ConnectHelper
+        except ImportError:
+            raise RuntimeError(
+                "pyOCD not installed. Run: pip install pyocd"
+            )
+        kwargs = {"target_override": self._target_name}
+        if self._probe:
+            kwargs["unique_id"] = self._probe
+        self._session = ConnectHelper.session_with_chosen_probe(**kwargs)
+        self._session.open()
+
+    def disconnect(self):
+        """Close pyOCD session."""
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    @property
+    def _target(self):
+        if self._session is None:
+            raise RuntimeError("Not connected — call connect() first")
+        return self._session.target
+
+    # ── basic debug ops ────────────────────────────────────
+
+    def halt(self) -> None:
+        """Halt the target CPU."""
+        self._target.halt()
+
+    def resume(self) -> None:
+        """Resume the target CPU."""
+        self._target.resume()
+
+    def read_core_regs(self) -> dict[str, int]:
+        """Return R0-R12, SP, LR, PC, xPSR as int values."""
+        t = self._target
+        regs: dict[str, int] = {}
+        for name in self._CORE_REG_NAMES:
+            val = t.read_core_register(name)
+            regs[name.upper()] = val
+        return regs
+
+    def read_fault_regs(self) -> dict[str, int]:
+        """Read SCB fault status/address registers.
+
+        Returns: CFSR, HFSR, MMFAR, BFAR (all 32-bit ints).
+        """
+        t = self._target
+        return {
+            "CFSR":  t.read32(self._SCB_BASE + self._CFSR_OFF),
+            "HFSR":  t.read32(self._SCB_BASE + self._HFSR_OFF),
+            "MMFAR": t.read32(self._SCB_BASE + self._MMFAR_OFF),
+            "BFAR":  t.read32(self._SCB_BASE + self._BFAR_OFF),
+        }
+
+    def read_mem(self, addr: int, length: int) -> bytes:
+        """Read *length* bytes from *addr*."""
+        return bytes(self._target.read_memory_block8(addr, length))
+
+    # ── stack unwind ───────────────────────────────────────
+
+    def stack_backtrace(self, max_frames: int = 32) -> list[StackFrame]:
+        """Walk the call stack from current register state.
+
+        Uses a simple AAPCS LR-chain unwind.  For BH1098 this covers
+        most C functions (compiled with frame pointers off by default in
+        IAR, so we fall back to LR-based heuristics).
+
+        Returns one frame for the current PC context; deeper unwind needs
+        DWARF .debug_frame which is not yet implemented.
+        """
+        regs = self.read_core_regs()
+        frames = [
+            StackFrame(
+                pc=regs["PC"],
+                sp=regs["SP"],
+                lr=regs["LR"],
+            )
+        ]
+        # Placeholder: deeper unwind via .debug_frame table
+        # (requires pyelftools or elftools for DWARF CFI parsing)
+        return frames[:max_frames]
+
+    # ── crash dump ─────────────────────────────────────────
+
+    def crash_dump(self) -> CrashDump:
+        """Halt CPU, capture full crash context, then resume.
+
+        Returns a CrashDump with fault classification, all core regs,
+        SCB fault regs, and stack backtrace.
+        """
+        self.halt()
+        try:
+            regs = self.read_core_regs()
+            faults = self.read_fault_regs()
+            stack = self.stack_backtrace()
+            fault_type = self._classify_fault(faults["CFSR"])
+        finally:
+            try:
+                self.resume()
+            except Exception:
+                pass  # resume may fail if CPU is truly wedged
+
+        return CrashDump(
+            fault_type=fault_type,
+            pc=regs["PC"],
+            sp=regs["SP"],
+            lr=regs["LR"],
+            cfsr=faults["CFSR"],
+            hfsr=faults["HFSR"],
+            mmfar=faults["MMFAR"],
+            bfar=faults["BFAR"],
+            core_regs=regs,
+            stack=stack,
+        )
+
+    @staticmethod
+    def _classify_fault(cfsr: int) -> str:
+        """Map CFSR bits to a human-readable fault name.
+
+        CFSR bits (ARMv7-M Architecture Reference Manual):
+          - IACCVIOL(0), DACCVIOL(1), STKERR(4), UNSTKERR(8),
+            INVPC(12), INVSTATE(17), UNDEFINSTR(18), UNALIGNED(24), DIVBYZERO(25)
+        """
+        if cfsr == 0:
+            return "NoFault"
+
+        names = []
+        if cfsr & (1 << 25): names.append("DIVBYZERO")
+        if cfsr & (1 << 24): names.append("UNALIGNED")
+        if cfsr & (1 << 19): names.append("NOCP")
+        if cfsr & (1 << 18): names.append("UNDEFINSTR")
+        if cfsr & (1 << 17): names.append("INVSTATE")
+        if cfsr & (1 << 12): names.append("INVPC")
+        if cfsr & (1 << 11): names.append("UNSTKERR")
+        if cfsr & (1 << 8):  names.append("UNSTKERR")
+        if cfsr & (1 << 4):  names.append("STKERR")
+        if cfsr & (1 << 3):  names.append("MUNSTKERR")
+        if cfsr & (1 << 1):  names.append("DACCVIOL")
+        if cfsr & (1 << 0):  names.append("IACCVIOL")
+
+        return "/".join(names) if names else f"UNKNOWN(0x{cfsr:08X})"

--- a/test/vsf_bench/hardware_map.py
+++ b/test/vsf_bench/hardware_map.py
@@ -8,10 +8,14 @@ from vsf_bench.config import (
     ArtifactConfig,
     BoardConfig,
     BuildConfig,
-    BuilderConfig,
     LogicAnalyzerConfig,
+    PipelineConfig,
+    PowerConfig,
+    ProjectConfig,
     RunnerConfig,
+    StageConfig,
 )
+from vsf_bench.hwctrl.match_serial import match_serial_port
 
 
 def _resolve_yaml_path(value: str, yaml_dir: Path) -> str:
@@ -36,36 +40,29 @@ def _derive_board_name(entry: dict) -> str:
     return entry.get("platform", "unknown")
 
 
-def _entry_to_board(entry: dict, yaml_dir: Path) -> BoardConfig:
-    """Convert one YAML entry to a BoardConfig (no name filtering)."""
-    build_cfg = entry.get("build", {})
-    build_artifacts = [
-        ArtifactConfig(name=a["name"], format=a["format"])
-        for a in build_cfg.get("artifacts", [])
-    ]
+def _parse_build_config(build_cfg: dict, yaml_dir: Path) -> BuildConfig:
+    """Parse the ``build`` section.  Known keys go to BuildConfig fields;
+    everything else becomes builder params.
+    """
+    known = {"source_dir", "build_dir", "tool", "artifacts"}
+    params = {k: v for k, v in build_cfg.items() if k not in known}
 
-    builders = {}
-    for name, cfg in build_cfg.get("builders", {}).items():
-        params = {k: v for k, v in cfg.items() if k != "type"}
-        builders[name] = BuilderConfig(
-            type=cfg["type"],
-            params=params,
-        )
-
-    build_tool = build_cfg.get("build_tool", "cmake")
-    if not builders and build_tool:
-        builders[build_tool] = BuilderConfig(type=build_tool)
-
-    build = BuildConfig(
+    return BuildConfig(
         source_dir=_resolve_yaml_path(build_cfg.get("source_dir", ""), yaml_dir),
         build_dir=_resolve_yaml_path(build_cfg.get("build_dir", ""), yaml_dir),
-        build_tool=build_tool,
-        builders=builders,
-        artifacts=build_artifacts,
+        tool=build_cfg.get("tool", "cmake"),
+        params=params,
+        artifacts=[
+            ArtifactConfig(name=a["name"], format=a["format"])
+            for a in build_cfg.get("artifacts", [])
+        ],
     )
 
+
+def _parse_runners(runners_raw: dict) -> dict[str, RunnerConfig]:
+    """Parse the ``runners`` section shared by board entries and project entries."""
     runners = {}
-    for name, cfg in entry.get("runners", {}).items():
+    for name, cfg in runners_raw.items():
         artifact_raw = cfg.get("artifact")
         artifact = None
         if artifact_raw:
@@ -73,13 +70,115 @@ def _entry_to_board(entry: dict, yaml_dir: Path) -> BoardConfig:
                 name=artifact_raw["name"],
                 format=artifact_raw["format"],
             )
-        params = {k: v for k, v in cfg.items()
-                  if k not in ("type", "artifact")}
+        if "params" in cfg and isinstance(cfg["params"], dict):
+            params = dict(cfg["params"])
+        else:
+            params = {k: v for k, v in cfg.items()
+                      if k not in ("type", "artifact")}
         runners[name] = RunnerConfig(
             type=cfg["type"],
             artifact=artifact,
             params=params,
         )
+    return runners
+
+
+def _entry_to_board(entry: dict, yaml_dir: Path, hubs: dict | None = None, gpio_adapters: dict | None = None) -> BoardConfig:
+    """Convert one YAML board entry to a BoardConfig (no name filtering)."""
+    la_cfg = None
+    la_raw = entry.get("logic_analyzer")
+    if la_raw:
+        cli_raw = la_raw.get("cli")
+        la_cfg = LogicAnalyzerConfig(
+            cli=_resolve_yaml_path(cli_raw, yaml_dir) if cli_raw else None,
+            device=la_raw.get("device", "DSLogic"),
+            samplerate=la_raw.get("samplerate", "10M"),
+            capture_duration=float(la_raw.get("capture_duration", 120)),
+            channels=la_raw.get("channels", {}),
+        )
+
+    # ── UART ports ──
+    log_raw = entry.get("debug_uart", entry.get("serial", ""))
+    if isinstance(log_raw, dict):
+        debug_uart = match_serial_port(log_raw, label=f"board {_derive_board_name(entry)} log UART")
+        debug_baudrate = log_raw.get("baudrate", entry.get("baud", 0))
+    else:
+        debug_uart = log_raw
+        debug_baudrate = entry.get("baud", 0)
+
+    dl_raw = entry.get("program_uart", entry.get("download_serial", ""))
+    if isinstance(dl_raw, dict):
+        program_uart = match_serial_port(dl_raw, label=f"board {_derive_board_name(entry)} download UART")
+    else:
+        program_uart = dl_raw
+
+    # ── Power (resolve hub reference) ──
+    power = None
+    power_raw = entry.get("power")
+    if power_raw:
+        hub_name = power_raw.get("hub", "")
+        hub_cfg = hubs.get(hub_name, {}) if hubs else {}
+        power = PowerConfig(
+            hub_addr=hub_cfg.get("hub_addr", power_raw.get("hub_addr")),
+            port=power_raw.get("port", 3),
+        )
+
+    # ── DFU key (resolve gpio reference) ──
+    dfu_key = entry.get("dfu_key")
+    gpio_adapter_serial = ""
+    if dfu_key and gpio_adapters:
+        gpio_name = dfu_key.get("gpio", "")
+        gpio_cfg = gpio_adapters.get(gpio_name, {})
+        gpio_adapter_serial = gpio_cfg.get("adapter_serial", "")
+    if not dfu_key:
+        dfu_key = None
+
+    board = BoardConfig(
+        platform=entry.get("platform", ""),
+        connected=entry.get("connected", True),
+        debug_uart=debug_uart,
+        debug_baudrate=debug_baudrate,
+        program_uart=program_uart,
+        power=power,
+        fixtures=entry.get("fixtures", []),
+        logic_analyzer=la_cfg,
+        debug_probe=entry.get("debug_probe"),
+        dfu_key=dfu_key,
+        gpio_adapter_serial=gpio_adapter_serial,
+        board_pins=_resolve_yaml_path(entry.get("board_pins", ""), yaml_dir),
+        name=_derive_board_name(entry),
+    )
+    board.validate()
+    return board
+
+
+def _entry_to_project(project_name: str, entry: dict, yaml_dir: Path) -> ProjectConfig:
+    """Convert one YAML project entry to a ProjectConfig."""
+    build_cfg = entry.get("build", {})
+    build = _parse_build_config(build_cfg, yaml_dir)
+
+    runners = _parse_runners(entry.get("runners", {}))
+
+    project = ProjectConfig(
+        build=build,
+        active_runner=entry.get("active_runner", ""),
+        runners=runners,
+        name=project_name,
+    )
+    project.validate()
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible board-centric loaders (used by existing test codepaths)
+# ---------------------------------------------------------------------------
+
+def _entry_to_board_legacy(entry: dict, yaml_dir: Path) -> BoardConfig:
+    """Convert one YAML entry (old flat format) to a BoardConfig with embedded
+    build/runner fields for backward compatibility."""
+    build_cfg = entry.get("build", {})
+    build = _parse_build_config(build_cfg, yaml_dir)
+    runners = _parse_runners(entry.get("runners", {}))
 
     la_cfg = None
     la_raw = entry.get("logic_analyzer")
@@ -93,20 +192,28 @@ def _entry_to_board(entry: dict, yaml_dir: Path) -> BoardConfig:
             channels=la_raw.get("channels", {}),
         )
 
-    board = BoardConfig(
+    # Legacy BoardConfig expects active_runner, runners, build
+    # Use setattr to work around the fact that these fields no longer exist
+    # on the canonical BoardConfig.
+    from dataclasses import fields as dc_fields
+    legacy_field_names = {f.name for f in dc_fields(BoardConfig)}
+    kwargs = dict(
         platform=entry.get("platform", ""),
         connected=entry.get("connected", True),
-        active_runner=entry.get("active_runner", ""),
-        runners=runners,
-        serial=entry.get("serial", ""),
-        baud=entry.get("baud", 0),
-        build=build,
+        debug_uart=entry.get("serial", ""),
+        debug_baudrate=entry.get("baud", 0),
         fixtures=entry.get("fixtures", []),
         logic_analyzer=la_cfg,
         board_pins=_resolve_yaml_path(entry.get("board_pins", ""), yaml_dir),
         name=_derive_board_name(entry),
     )
-    board.validate()
+    board = BoardConfig(**kwargs)
+
+    # Attach legacy fields dynamically for backward compat
+    board.active_runner = entry.get("active_runner", "")          # type: ignore[attr-defined]
+    board.runners = runners                                        # type: ignore[attr-defined]
+    board.build = build                                            # type: ignore[attr-defined]
+
     return board
 
 
@@ -121,7 +228,7 @@ def load(path: str | Path, board_name: str | None = None) -> BoardConfig:
     """
     p = Path(path)
     yaml_dir = p.parent.resolve()
-    with open(p) as f:
+    with open(p, encoding="utf-8") as f:
         entries = yaml.safe_load(f)
 
     if not entries:
@@ -134,7 +241,7 @@ def load(path: str | Path, board_name: str | None = None) -> BoardConfig:
     if board_name:
         for entry in connected:
             if _derive_board_name(entry) == board_name:
-                return _entry_to_board(entry, yaml_dir)
+                return _entry_to_board(entry, yaml_dir, hubs, gpio_adapters)
         names = [_derive_board_name(e) for e in connected]
         raise RuntimeError(
             f"Board '{board_name}' not found in hardware-map.yml. "
@@ -149,35 +256,132 @@ def load(path: str | Path, board_name: str | None = None) -> BoardConfig:
             file=sys.stderr,
         )
 
-    return _entry_to_board(connected[0], yaml_dir)
+    return _entry_to_board_legacy(connected[0], yaml_dir)
 
 
 def load_all(path: str | Path) -> list[BoardConfig]:
-    """Return all connected boards from a hardware-map.yml file."""
+    """Return all connected boards from a hardware-map.yml file (legacy format)."""
     p = Path(path)
     yaml_dir = p.parent.resolve()
-    with open(p) as f:
+    with open(p, encoding="utf-8") as f:
         entries = yaml.safe_load(f)
 
     return [
-        _entry_to_board(e, yaml_dir)
+        _entry_to_board_legacy(e, yaml_dir)
         for e in entries
         if e.get("connected", False)
     ]
 
 
-def validate_runners(board: BoardConfig) -> None:
+# ---------------------------------------------------------------------------
+# Board+project loader
+# ---------------------------------------------------------------------------
+
+def load_board_and_project(
+    path: str | Path,
+    board_name: str | None = None,
+    project_name: str | None = None,
+) -> tuple[BoardConfig, ProjectConfig]:
+    """Load a board and project from a hardware-map.yml file.
+
+    The YAML must have top-level ``boards`` and ``projects`` sections (the
+    hardware_map format).  *board_name* and *project_name* select specific entries;
+    when omitted the first connected board / first project is used.
+
+    Returns ``(BoardConfig, ProjectConfig)``.
+    """
+    p = Path(path)
+    yaml_dir = p.parent.resolve()
+    with open(p, encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+
+    if not isinstance(doc, dict):
+        raise RuntimeError(
+            f"Expected a mapping with 'boards' and 'projects' keys, got {type(doc).__name__}"
+        )
+
+    boards_raw = doc.get("boards", [])
+    projects_raw = doc.get("projects", {})
+    hubs = doc.get("smartusb_hubs", {})
+    gpio_adapters = doc.get("gpio_adapters", {})
+
+    if not boards_raw:
+        raise RuntimeError("No 'boards' section in hardware-map.yml")
+    if not projects_raw:
+        raise RuntimeError("No 'projects' section in hardware-map.yml")
+
+    # --- Board selection ---
+    connected = [e for e in boards_raw if e.get("connected", False)]
+    if not connected:
+        raise RuntimeError("No connected board found in hardware-map.yml")
+
+    if board_name:
+        entry = None
+        for e in connected:
+            if _derive_board_name(e) == board_name:
+                entry = e
+                break
+        if entry is None:
+            names = [_derive_board_name(e) for e in connected]
+            raise RuntimeError(
+                f"Board '{board_name}' not found. Available: {names}"
+            )
+    else:
+        if len(connected) > 1:
+            names = [_derive_board_name(e) for e in connected]
+            print(
+                f"[vsf-bench] Multiple connected boards: {names}. "
+                f"Using '{names[0]}'. Use --board to select.",
+                file=sys.stderr,
+            )
+        entry = connected[0]
+
+    board = _entry_to_board(entry, yaml_dir, hubs, gpio_adapters)
+
+    # --- Project selection ---
+    if not project_name:
+        project_name = next(iter(projects_raw.keys()))
+        if len(projects_raw) > 1:
+            print(
+                f"[vsf-bench] Multiple projects: {list(projects_raw.keys())}. "
+                f"Using '{project_name}'. Use --project to select.",
+                file=sys.stderr,
+            )
+
+    proj_entry = projects_raw.get(project_name)
+    if proj_entry is None:
+        raise RuntimeError(
+            f"Project '{project_name}' not found. "
+            f"Available: {list(projects_raw.keys())}"
+        )
+
+    project = _entry_to_project(project_name, proj_entry, yaml_dir)
+    return board, project
+
+
+# ---------------------------------------------------------------------------
+# Runner validation
+# ---------------------------------------------------------------------------
+
+def validate_runners(target, build_artifacts=None) -> None:
     """Validate runner params against their class definitions.
 
+    *target* can be a BoardConfig (legacy — runners/build attached dynamically),
+    a ProjectConfig, or any object with ``.runners`` and ``.build`` attributes.
+
     Checks REQUIRED_PARAMS, class-specific validate_params(), and artifact
-    cross-reference against build.artifacts. Uses inline import to avoid
-    circular dependency with runner modules.
+    cross-reference against build.artifacts.
     """
     from vsf_bench.runners.registry import get_runner_class
 
     errors = []
+    runners = getattr(target, "runners", {})
+    build = getattr(target, "build", None)
+    artifacts = build_artifacts
+    if artifacts is None and build is not None:
+        artifacts = getattr(build, "artifacts", [])
 
-    for name, runner_cfg in board.runners.items():
+    for name, runner_cfg in runners.items():
         cls = get_runner_class(runner_cfg.type)
         if cls is None:
             continue  # custom runner (post-MVP), skip validation
@@ -191,15 +395,15 @@ def validate_runners(board: BoardConfig) -> None:
 
         if runner_cfg.artifact is None:
             errors.append(f"runners.{name}: missing required 'artifact' field")
-        else:
-            build_names = {a.name for a in board.build.artifacts}
+        elif artifacts:
+            build_names = {a.name for a in artifacts}
             if runner_cfg.artifact.name not in build_names:
                 errors.append(
                     f"runners.{name}.artifact '{runner_cfg.artifact.name}' "
                     f"not found in build.artifacts"
                 )
 
-    for name, runner_cfg in board.runners.items():
+    for name, runner_cfg in runners.items():
         if runner_cfg.artifact and runner_cfg.artifact.format not in (
             "elf", "uf2", "bin", "hex",
         ):
@@ -209,3 +413,113 @@ def validate_runners(board: BoardConfig) -> None:
 
     if errors:
         raise ValueError("Runner validation failed:\n  " + "\n  ".join(errors))
+
+
+# ---------------------------------------------------------------------------
+# Pipeline loading
+# ---------------------------------------------------------------------------
+
+def load_pipeline(
+    hardware_map_path: str,
+    pipeline_name: str,
+) -> PipelineConfig:
+    """Parse a named pipeline from hardware-map.yml ``pipelines`` section.
+
+    Returns a ``PipelineConfig`` whose ``stages`` each have a ``project``
+    *name* (str).  Call ``resolve_pipeline_projects()`` afterwards to
+    replace those strings with ``ProjectConfig`` instances.
+    """
+    with open(hardware_map_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+
+    pipelines_raw = raw.get("pipelines", {})
+    if not pipelines_raw:
+        raise ValueError(
+            f"No 'pipelines' section found in {hardware_map_path}"
+        )
+
+    if pipeline_name not in pipelines_raw:
+        raise ValueError(
+            f"Pipeline '{pipeline_name}' not found in {hardware_map_path}. "
+            f"Available: {list(pipelines_raw.keys())}"
+        )
+
+    entry = pipelines_raw[pipeline_name]
+    stages = []
+    for i, s in enumerate(entry.get("stages", [])):
+        actions = s.get("actions", [])
+        if not actions:
+            raise ValueError(
+                f"Pipeline '{pipeline_name}' stage {i}: 'actions' is required"
+            )
+        stages.append(StageConfig(
+            project=s["project"],
+            actions=actions,
+            flash_overrides=s.get("flash_overrides"),
+            wait_for=s.get("wait_for"),
+            power_cycle=s.get("power_cycle", False),
+        ))
+
+    return PipelineConfig(
+        name=pipeline_name,
+        description=entry.get("description", ""),
+        stages=stages,
+    )
+
+
+def list_pipelines(hardware_map_path: str) -> list[PipelineConfig]:
+    """Return all pipelines defined in hardware-map.yml (names only, no resolution)."""
+    with open(hardware_map_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    pipelines_raw = raw.get("pipelines", {})
+    result = []
+    for name, entry in pipelines_raw.items():
+        result.append(PipelineConfig(
+            name=name,
+            description=entry.get("description", ""),
+            stages=[],  # not resolved here
+        ))
+    return result
+
+
+def resolve_pipeline_projects(
+    pipeline: PipelineConfig,
+    hardware_map_path: str,
+    board_name: str | None = None,
+) -> dict[str, ProjectConfig]:
+    """Load all ProjectConfig instances referenced by pipeline stages.
+
+    *board_name* is forwarded to avoid the "Multiple connected boards"
+    warning when the caller has already selected a board.
+    """
+    project_names = {s.project for s in pipeline.stages}
+    project_map: dict[str, ProjectConfig] = {}
+
+    for name in project_names:
+        _, project = load_board_and_project(
+            hardware_map_path, project_name=name, board_name=board_name,
+        )
+        project_map[name] = project
+
+    return project_map
+
+
+def load_project(hardware_map_path: str, project_name: str) -> ProjectConfig:
+    """Load a single project from hardware-map.yml without resolving a board."""
+    p = Path(hardware_map_path)
+    yaml_dir = p.parent.resolve()
+    with open(p, encoding="utf-8") as f:
+        doc = yaml.safe_load(f) or {}
+    projects_raw = doc.get("projects", {})
+    if project_name not in projects_raw:
+        raise ValueError(
+            f"Project '{project_name}' not found. Available: {list(projects_raw.keys())}"
+        )
+    return _entry_to_project(project_name, projects_raw[project_name], yaml_dir)
+
+
+def load_defaults(hardware_map_path: str) -> dict:
+    """Return the ``defaults`` section from hardware-map.yml, or {}."""
+    with open(hardware_map_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    return raw.get("defaults", {})

--- a/test/vsf_bench/hwctrl/match_serial.py
+++ b/test/vsf_bench/hwctrl/match_serial.py
@@ -1,0 +1,60 @@
+"""Serial port matching by VID/PID/serial/desc.
+
+Extracted from devtool.py so hardware-map.yml can use descriptive
+port matching instead of hard-coded COM port strings.
+"""
+
+import serial.tools.list_ports
+
+
+def match_serial_port(match_cfg, label: str = "serial port") -> str:
+    """Resolve a serial port from match criteria.
+
+    Supports two forms:
+      - str: direct port name (``"COM38"``) — backward compatible
+      - dict: match criteria with any combination of:
+          ``vid``, ``pid``, ``serial``, ``desc``, ``port``
+
+    All criteria are AND-ed.  Returns the resolved port name string.
+    """
+    if isinstance(match_cfg, str):
+        return match_cfg
+
+    vid = match_cfg.get("vid")
+    pid = match_cfg.get("pid")
+    sn = match_cfg.get("serial")
+    desc = match_cfg.get("desc")
+    location = match_cfg.get("location")
+    explicit_port = match_cfg.get("port")
+
+    vid = int(vid) if vid is not None else None
+    pid = int(pid) if pid is not None else None
+
+    candidates = []
+    for port in serial.tools.list_ports.comports():
+        if vid is not None and port.vid != vid:
+            continue
+        if pid is not None and port.pid != pid:
+            continue
+        if sn is not None and sn not in (port.serial_number or ""):
+            continue
+        if desc is not None and desc not in (port.description or ""):
+            continue
+        if location is not None and location not in (port.location or ""):
+            continue
+        candidates.append(port.device)
+
+    if len(candidates) == 0:
+        raise RuntimeError(f"{label}: no port matching criteria")
+    if len(candidates) == 1:
+        return candidates[0]
+    if explicit_port:
+        pn = explicit_port.upper().replace("/", "\\")
+        for c in candidates:
+            if c.upper().replace("/", "\\") == pn:
+                return c
+    raise RuntimeError(f"{label}: {len(candidates)} ports match, use 'port' to disambiguate: {candidates}")
+
+
+# Backward-compat alias
+resolve_serial_port = match_serial_port

--- a/test/vsf_bench/hwctrl/tee_logger.py
+++ b/test/vsf_bench/hwctrl/tee_logger.py
@@ -1,0 +1,70 @@
+"""TeeLogger: thread-safe stream logging to terminal + file.
+
+Extracted from devtool.py so vsf-bench can log script events and device
+output with ISO timestamps to both the terminal and a log file.
+
+Singleton pattern: ``get_logger()`` / ``init_logger(log_dir)``.
+"""
+
+import threading
+from datetime import datetime
+from pathlib import Path
+
+_logger_instance: "TeeLogger | None" = None
+
+
+def _format_timestamp():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+class TeeLogger:
+    """Thread-safe logger for terminal + file output."""
+
+    def __init__(self, log_path: Path | str | None = None):
+        self._file = None
+        self._lock = threading.Lock()
+        if log_path is not None:
+            p = Path(log_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            self._file = open(p, "w", encoding="utf-8")
+
+    def _log(self, prefix, message):
+        line = f"{_format_timestamp()} {prefix} {message}"
+        with self._lock:
+            print(line)
+            if self._file:
+                self._file.write(line + "\n")
+                self._file.flush()
+
+    def event(self, message):
+        self._log("[vsf-bench]", message)
+
+    def device(self, line_text):
+        self._log("[DEV]", line_text)
+
+    def raw(self, text):
+        with self._lock:
+            print(text)
+
+    def close(self):
+        with self._lock:
+            if self._file:
+                self._file.close()
+                self._file = None
+
+
+def init_logger(log_dir: Path | str | None = None) -> TeeLogger:
+    """Create and register the singleton TeeLogger.  Call once at startup."""
+    global _logger_instance
+    log_path = None
+    if log_dir is not None:
+        log_path = Path(log_dir) / "console.log"
+    _logger_instance = TeeLogger(log_path)
+    return _logger_instance
+
+
+def get_logger() -> TeeLogger:
+    """Return the singleton logger.  Raises if not initialized."""
+    if _logger_instance is None:
+        raise RuntimeError("TeeLogger not initialized — call init_logger() first")
+    return _logger_instance

--- a/test/vsf_bench/lock.py
+++ b/test/vsf_bench/lock.py
@@ -20,7 +20,8 @@ import os
 import time
 from pathlib import Path
 
-LOCK_DIR = Path("/tmp/vsf-bench-locks")
+import tempfile
+LOCK_DIR = Path(tempfile.gettempdir()) / "vsf-bench-locks"
 
 
 class LockBusyError(RuntimeError):

--- a/test/vsf_bench/pipeline.py
+++ b/test/vsf_bench/pipeline.py
@@ -3,7 +3,7 @@
 Each phase function does one thing and is called by exactly one CLI entry:
   * `load_board()`   — YAML → BoardConfig (used by all)
   * `build_phase()`  — cmake build (vsf-bench-build)
-  * `flash_phase()`  — runner flash (vsf-bench-flash)
+  * `program_phase()`  — runner flash (vsf-bench-flash)
   * `run_test_phase()` — multi-suite LA-aware test orchestration (vsf-bench-test)
 
 The unified `vsf-bench` entry (`cli/run.py`) composes these in order based on
@@ -19,27 +19,44 @@ from datetime import datetime
 from pathlib import Path
 
 from vsf_bench.hardware_map import load as load_hardware_map, validate_runners
+from vsf_bench.hardware_map import load_board_and_project as _load_board_and_project
 from vsf_bench.builders.registry import get_builder_class
 from vsf_bench.runners.registry import get_runner_class
 from vsf_bench.instruments.serial_instrument import SerialInstrument
 from vsf_bench.instruments.logic_analyzer_instrument import LogicAnalyzerInstrument
+from vsf_bench.vsf_test_shell import VsfTestShellProtocol
 from vsf_bench.lock import BoardLock, LockBusyError
 from vsf_bench.suite import discover_suites, load_script_module, script_needs_la, resolve_suites
 from vsf_bench.test_params_loader import load_test_params
+from vsf_bench.hwctrl.tee_logger import get_logger as _get_logger
 
 
-def __bprint(*args, **kwargs):
-    """Print with ISO timestamp and [vsf-bench] prefix."""
-    ts = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-    print(f"[{ts}] [vsf-bench]", *args, **kwargs)
+def __log_event(message):
+    """Log a vsf-bench event. Uses TeeLogger when available, else print."""
+    try:
+        _get_logger().event(message)
+    except RuntimeError:
+        from datetime import datetime as _dt
+        ts = _dt.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        print(f"[{ts}] [vsf-bench] {message}")
 
 
-def load_board(hardware_map_path: Path, board_name: str | None = None):
-    """Read hardware-map.yml and return a validated board config.
+def load_board(hardware_map_path: Path, board_name: str | None = None,
+               project_name: str | None = None):
+    """Read hardware-map.yml and return (BoardConfig, ProjectConfig) or BoardConfig.
 
-    *board_name=None* → first connected board (backward compatible).
-    *board_name=<name>* → select a specific board by name / serial port.
+    *project_name=None* (legacy) → returns BoardConfig with embedded build/runner.
+    *project_name=<name>* → returns ``(board, project)`` tuple.
     """
+    if project_name is not None:
+        board, project = _load_board_and_project(
+            str(hardware_map_path), board_name=board_name,
+            project_name=project_name,
+        )
+        validate_runners(project, build_artifacts=project.build.artifacts)
+        return board, project
+
+    # Legacy path
     board = load_hardware_map(str(hardware_map_path), board_name=board_name)
     validate_runners(board)
     return board
@@ -59,61 +76,129 @@ def acquire_board_lock(board, wait_spec=None) -> BoardLock | None:
         lock.acquire(wait=True)
     else:
         lock.acquire(wait=True, timeout=wait_spec)
-    __bprint(f"Lock acquired: {board.name}")
+    __log_event(f"Lock acquired: {board.name}")
     return lock
 
 
-def build_phase(board) -> Path:
-    """Run the configured build tool → return build_dir. Raises on error."""
-    build_tool = board.build.build_tool
-    builder_cfg = board.build.builders.get(build_tool)
-    if builder_cfg is None:
-        raise RuntimeError(f"Build tool '{build_tool}' not found in builders map")
-    builder_cls = get_builder_class(builder_cfg.type)
+def build_phase(build_src) -> Path:
+    """Run the configured build tool → return build_dir. Raises on error.
+
+    *build_src* can be a BoardConfig (legacy, ``.build`` attr) or a
+    ProjectConfig / BuildConfig directly.
+    """
+    build = getattr(build_src, "build", build_src)
+    builder_cls = get_builder_class(build.tool)
     if builder_cls is None:
-        raise RuntimeError(f"Unknown builder type: {builder_cfg.type}")
-    __bprint(f"Building ({board.build.source_dir}) via {build_tool}...")
-    builder = builder_cls(board.build)
+        raise RuntimeError(f"Unknown build tool: {build.tool}")
+    __log_event(f"Building ({build.source_dir}) via {build.tool}...")
+    builder = builder_cls(build)
     build_dir = builder.build()
-    __bprint(f"Build complete: {build_dir}")
+    __log_event(f"Build complete: {build_dir}")
     return build_dir
 
 
-def flash_phase(board, build_dir: Path) -> None:
-    """Run the active flash runner. Raises on runner error."""
-    runner_cfg = board.runners[board.active_runner]
+def _find_hub_by_addr(hub_addr: int) -> str | None:
+    """Find SmartUSBHub COM port by querying device address."""
+    import serial.tools.list_ports
+    from smartusbhub import SmartUSBHub
+    for port in serial.tools.list_ports.comports():
+        if port.vid != 0x1A86 or port.pid != 0xFE0C:
+            continue
+        try:
+            hub = SmartUSBHub(port.device)
+            addr = hub.get_device_address()
+            hub.disconnect()
+            if addr == hub_addr:
+                return port.device
+        except Exception:
+            continue
+    return None
+
+
+def _board_power_cycle(board, delay_off_s: float = 0.5) -> None:
+    """Power-cycle *board* with randomised exponential backoff.
+
+    Encapsulates SmartUSBHub resolution and retry — callers don't need
+    to know about hub COM ports or contention handling.
+    """
+    if not board.power:
+        raise RuntimeError(f"Board '{board.name}' has no power config")
+    if board.power.type != "smartusbhub":
+        raise RuntimeError(f"Unsupported power type: {board.power.type}")
+
+    # Resolve SmartUSBHub COM port by querying device address
+    hub_com = _find_hub_by_addr(board.power.hub_addr)
+    if not hub_com:
+        raise RuntimeError(
+            f"SmartUSBHub with addr 0x{board.power.hub_addr:04X} not found"
+        )
+
+    import random as _random
+    try:
+        from smartusbhub import SmartUSBHub
+    except ImportError:
+        raise RuntimeError("smartusbhub not installed — cannot power-cycle")
+
+    def _cmd(state, label):
+        last_exc = None
+        for attempt in range(1, 11):
+            try:
+                hub = SmartUSBHub(hub_com)
+                try:
+                    hub.set_channel_power(board.power.port, state=state)
+                finally:
+                    hub.disconnect()
+                __log_event(f"power {label} port {board.power.port}")
+                return
+            except Exception as e:
+                last_exc = e
+                if attempt < 10:
+                    delay = min(0.02 * (2 ** (attempt - 1)), 5.0)
+                    time.sleep(delay + delay * _random.uniform(-0.5, 0.5))
+        raise last_exc
+
+    _cmd(0, "off")
+    if delay_off_s > 0:
+        time.sleep(delay_off_s)
+    _cmd(1, "on")
+
+
+def program_phase(board_or_project, build_dir: Path, project=None) -> None:
+    """Power-cycle board (if configured), then run flash runner."""
+    board = board_or_project
+
+    if project is not None:
+        active_runner = project.active_runner
+        runners = project.runners
+    else:
+        active_runner = board.active_runner
+        runners = board.runners
+
+    runner_cfg = runners[active_runner]
+
+    # Power-cycle before flash.
     runner_cls = get_runner_class(runner_cfg.type)
     if runner_cls is None:
         raise RuntimeError(f"Unknown runner type: {runner_cfg.type}")
     runner = runner_cls(runner_cfg)
-    __bprint(f"Flashing via {board.active_runner}...")
-    runner.flash(build_dir)
-    __bprint("Flash complete")
+
+    with runner:
+        _board_power_cycle(board)
+
+        __log_event(f"Programming via {active_runner}...")
+        runner.flash(build_dir)
+
+    # close() called automatically on exit
+    __log_event("Program complete")
 
 
 # ---------------------------------------------------------------------------
 # Test phase
 # ---------------------------------------------------------------------------
 
-def _query_firmware_suites(ser: SerialInstrument) -> set[str]:
-    ser.send("vsf-test list-suites\r\n")
-    time.sleep(0.3)
-    output = ser.read_all(timeout=2.0)
-    suites: set[str] = set()
-    for line in output.splitlines():
-        line = line.strip()
-        if line and line[0].isdigit():
-            parts = line.split(None, 1)
-            if len(parts) == 2:
-                suites.add(parts[1])
-    return suites
-
-
-def _build_run_cmd(suite: str, case: str | None) -> str:
-    if case:
-        return f"vsf-test run-case {suite} {case}\r\n"
-    return f"vsf-test run-suite {suite}\r\n"
-
+# ---------------------------------------------------------------------------
+# Helper: scenario lookup (used by _resolve_case_value and _run_script_phase1)
+# ---------------------------------------------------------------------------
 
 def _find_scenario_for_suite(params: dict, suite_name: str) -> tuple[str, dict] | None:
     """Find YAML scenario key and data for a given suite name.
@@ -164,21 +249,6 @@ def _resolve_case_value(params: dict, suite_name: str, case_value: str) -> int:
     )
 
 
-def _drain_repl(ser: SerialInstrument) -> None:
-    """Discard any stale REPL output left from a previous suite."""
-    ser.read_all(timeout=0.1)
-
-
-def _send_shuffle_seed(
-    ser: SerialInstrument, suite_name: str, seed: int
-) -> bool:
-    """Shuffle is no longer supported in the simplified shell (removed in shell
-    simplification). This is a no-op for backward CLI compatibility.
-    --random still works on the host side (Python randomizes suite order)."""
-    __bprint(f"{suite_name}: shuffle seed={seed} (host-side only)")
-    return True
-
-
 def _run_script_phase1(
     suite_name: str,
     case: str | None,
@@ -187,34 +257,32 @@ def _run_script_phase1(
     test_params_yml: Path | None = None,
 ) -> bool:
     """Send trigger, run script.run(). Returns True on PASS."""
+    shell = VsfTestShellProtocol(ser)
     case_tag = f".{case}" if case else ""
-    cmd = _build_run_cmd(suite_name, case)
-    _drain_repl(ser)
+    cmd = shell.build_run_cmd(suite_name, case)
+    shell.drain_repl()
     ser.send(cmd)
-    __bprint(f"Triggered: {cmd.strip()}")
+    __log_event(f"Triggered: {cmd.strip()}")
     t0 = time.perf_counter()
 
-    # vsf-test-shell emits "suite ack: <name>" on a successful lookup or
-    # "suite not found: <name>" / "Case not found: <case>" otherwise. One
-    # of these always fires within ~50 ms of the trigger.
-    # Retry once on timeout: stale output from the previous suite can delay
-    # the ack just past the 1 s boundary under heavy shared-LA load.
+    # vsf-test-shell emits "suite ack: <name>" on successful lookup,
+    # "suite not found: <name>" / "case not found: <case>" otherwise.
+    # Retry once on timeout: stale output from previous suite can delay ack.
     ack = None
     for attempt, tmo in ((1, 1.0), (2, 2.0)):
-        try:
-            ack = ser.expect(r"\[vsf-test\](?: \[\d+\.\d+ s\])? suite ack:|\[vsf-test\](?: \[\d+\.\d+ s\])? suite not found:|\[vsf-test\](?: \[\d+\.\d+ s\])? case not found:", timeout=tmo)
+        ack = shell.expect_suite_ack(timeout=tmo)
+        if ack is not None:
             break
-        except TimeoutError:
-            if attempt == 1:
-                _drain_repl(ser)
-                ser.send(cmd)
-                __bprint(f"Retrying: {cmd.strip()}")
-            else:
-                __bprint(f"FAIL: {suite_name}{case_tag}: no shell ack within 1s")
-                return False
+        if attempt == 1:
+            shell.drain_repl()
+            ser.send(cmd)
+            __log_event(f"Retrying: {cmd.strip()}")
+        else:
+            __log_event(f"FAIL: {suite_name}{case_tag}: no shell ack within 1s")
+            return False
     assert ack is not None
     if "not found" in ack:
-        __bprint(f"FAIL: {suite_name}{case_tag}: {ack.strip()}")
+        __log_event(f"FAIL: {suite_name}{case_tag}: {ack.strip()}")
         return False
 
     try:
@@ -227,11 +295,11 @@ def _run_script_phase1(
         else:
             ser.expect_test_summary(suite_name, timeout=1.5)
         elapsed = time.perf_counter() - t0
-        __bprint(f"PASS phase1: {suite_name}{case_tag} ({elapsed:.3f} s)")
+        __log_event(f"PASS phase1: {suite_name}{case_tag} ({elapsed:.3f} s)")
         return True
     except (TimeoutError, AssertionError, RuntimeError, KeyError, AttributeError) as e:
         elapsed = time.perf_counter() - t0
-        __bprint(f"FAIL: {suite_name}{case_tag}: {e} ({elapsed:.3f} s)")
+        __log_event(f"FAIL: {suite_name}{case_tag}: {e} ({elapsed:.3f} s)")
         return False
 
 
@@ -296,8 +364,8 @@ def run_test_phase(
     if not ordered_suites:
         raise RuntimeError("No suites discovered")
 
-    __bprint(f"Suites: {[s for s, _ in ordered_suites]}")
-    __bprint(f"LA mode: {la_mode}")
+    __log_event(f"Suites: {[s for s, _ in ordered_suites]}")
+    __log_event(f"LA mode: {la_mode}")
     t0_overall = time.perf_counter()
 
     if case_specs and len(ordered_suites) > 1:
@@ -321,13 +389,13 @@ def run_test_phase(
             else:
                 idx = _resolve_case_value(params, suite_name, spec)
                 resolved.append(str(idx))
-                __bprint(f"Resolved --case {spec} -> index {idx}")
+                __log_event(f"Resolved --case {spec} -> index {idx}")
         case_specs = resolved
 
     run_dir = _mk_log_dir(log_dir, ordered_suites)
     log_path = run_dir / "vsf-bench.jsonl"
 
-    ser = SerialInstrument(board.serial, board.baud, audit_log=log_path)
+    ser = SerialInstrument(board.debug_uart, board.debug_baudrate, audit_log=log_path)
     ser.open()
 
     la_cfg = board.logic_analyzer
@@ -340,40 +408,26 @@ def run_test_phase(
             if cli_path:
                 cli_path = Path(cli_path)
 
-    # Drain any stale boot output, then wait for the shell prompt to appear.
-    _drain_repl(ser)
-    ser.send("\r\n")
-    shell_ready = False
-    for attempt in range(3):
-        try:
-            ser.expect("> ", timeout=2.0)
-            shell_ready = True
-            break
-        except TimeoutError:
-            _drain_repl(ser)
-            ser.send("\r\n")
+    shell = VsfTestShellProtocol(ser)
+
+    # Drain stale boot output, then wait for the shell prompt.
+    shell_ready = shell.wait_for_shell_ready()
     if not shell_ready:
-        __bprint("Warning: shell not responding, proceeding anyway")
+        __log_event("Warning: shell not responding, proceeding anyway")
 
     if trace_level and shell_ready:
-        ser.send(f"vsf-test trace-level {trace_level}\r\n")
-        try:
-            ser.expect("trace-level set:", timeout=1.0)
-            __bprint(f"Trace level: {trace_level}")
-        except TimeoutError:
-            # The ack may be mixed with the next prompt — consume the buffer
-            ser.read_all(timeout=0.3)
-            __bprint(f"Trace level: {trace_level} (set, ack lost in prompt)")
+        shell.set_trace_level(trace_level)
+        __log_event(f"Trace level: {trace_level}")
 
     # When no explicit --suite filter, intersect with what the firmware reports.
     if not suite_names:
-        fw_suites = _query_firmware_suites(ser)
+        fw_suites = shell.query_firmware_suites()
         if fw_suites:
             skipped = [s for s, _ in ordered_suites if s not in fw_suites]
             ordered_suites = [(s, p) for s, p in ordered_suites if s in fw_suites]
             if skipped:
-                __bprint(f"Skipped (not in firmware): {skipped}")
-        __bprint(f"Effective suites: {[s for s, _ in ordered_suites]}")
+                __log_event(f"Skipped (not in firmware): {skipped}")
+        __log_event(f"Effective suites: {[s for s, _ in ordered_suites]}")
 
     loaded: list[tuple[str, Path | None, object | None, bool]] = []
     for suite_name, script_path in ordered_suites:
@@ -408,8 +462,12 @@ def run_test_phase(
     elapsed_overall = time.perf_counter() - t0_overall
     print()
     suite_tag = ordered_suites[0][0] if len(ordered_suites) == 1 else f"{len(ordered_suites)} suites"
-    __bprint(f"{'PASS' if overall_pass else 'FAIL'} ({elapsed_overall:.3f} s)")
-    __bprint(f"Test: {suite_tag} | Log: {log_path}")
+    __log_event(f"{'PASS' if overall_pass else 'FAIL'} ({elapsed_overall:.3f} s)")
+    __log_event(f"Test: {suite_tag} | Log: {log_path}")
+
+    # JUnit XML report
+    _write_junit_xml(run_dir, overall_pass, ordered_suites)
+
     return overall_pass
 
 
@@ -444,16 +502,15 @@ def _test_loop_shared_la(
             shared_la.start(300.0)
             shared_la.wait_until_started(timeout=5.0)
             la_start_t = time.monotonic()
-            __bprint(f"Shared LA started -> {shared_capture}")
+            __log_event(f"Shared LA started -> {shared_capture}")
 
         cases_to_run = case_specs if case_specs else [None]
         for case in cases_to_run:
             if shuffle_seed is not None and case is None:
-                if not _send_shuffle_seed(ser, suite_name, shuffle_seed):
-                    overall_pass = False
-                    continue
+                # Shuffle is host-side only; firmware shell no longer accepts seed
+                __log_event(f"{suite_name}: shuffle seed={shuffle_seed} (host-side only)")
             case_tag = f".{case}" if case else ""
-            __bprint(f"Suite: {suite_name}{case_tag}")
+            __log_event(f"Suite: {suite_name}{case_tag}")
             t_start = int((time.monotonic() - la_start_t) * 1e9) if la_start_t is not None else 0
             ok = _run_script_phase1(suite_name, case, mod, ser, test_params_yml)
             t_end = int((time.monotonic() - la_start_t) * 1e9) if la_start_t is not None else 0
@@ -463,25 +520,25 @@ def _test_loop_shared_la(
                 suite_windows.append((suite_name, mod, t_start, t_end))
 
         if i == last_la_idx and shared_la is not None:
-            __bprint("Stopping shared LA...")
+            __log_event("Stopping shared LA...")
             shared_la.stop()
             try:
                 shared_la.wait(timeout=30.0)
             except (TimeoutError, RuntimeError) as e:
-                __bprint(f"LA wait warning: {e}")
+                __log_event(f"LA wait warning: {e}")
 
     for suite_name, mod, t_start, t_end in suite_windows:
         decode_start = max(0, t_start - SHARED_WINDOW_PAD_NS)
         decode_end = t_end + SHARED_WINDOW_PAD_NS
-        __bprint(f"Decoding (shared): {suite_name}  window=[{decode_start/1e9:.2f}s,{decode_end/1e9:.2f}s]")
+        __log_event(f"Decoding (shared): {suite_name}  window=[{decode_start/1e9:.2f}s,{decode_end/1e9:.2f}s]")
         t0_decode = time.perf_counter()
         try:
-            _call_decode(mod, shared_la, decode_start, decode_end, board.baud, test_params_yml)
+            _call_decode(mod, shared_la, decode_start, decode_end, board.debug_baudrate, test_params_yml)
             elapsed = time.perf_counter() - t0_decode
-            __bprint(f"PASS decode: {suite_name} ({elapsed:.3f} s)")
+            __log_event(f"PASS decode: {suite_name} ({elapsed:.3f} s)")
         except (AssertionError, RuntimeError, KeyError, AttributeError, FileNotFoundError) as e:
             elapsed = time.perf_counter() - t0_decode
-            __bprint(f"FAIL decode: {suite_name}: {e} ({elapsed:.3f} s)")
+            __log_event(f"FAIL decode: {suite_name}: {e} ({elapsed:.3f} s)")
             overall_pass = False
 
     return overall_pass
@@ -499,11 +556,10 @@ def _test_loop_per_suite(
         cases_to_run = case_specs if case_specs else [None]
         for case in cases_to_run:
             case_tag = f".{case}" if case else ""
-            __bprint(f"Suite: {suite_name}{case_tag}")
+            __log_event(f"Suite: {suite_name}{case_tag}")
             if shuffle_seed is not None and case is None:
-                if not _send_shuffle_seed(ser, suite_name, shuffle_seed):
-                    overall_pass = False
-                    continue
+                # Shuffle is host-side only; firmware shell no longer accepts seed
+                __log_event(f"{suite_name}: shuffle seed={shuffle_seed} (host-side only)")
 
             scene_la: LogicAnalyzerInstrument | None = None
             if needs_la and la_cfg is not None and cli_path is not None:
@@ -522,17 +578,315 @@ def _test_loop_per_suite(
                 try:
                     scene_la.wait(timeout=15.0)
                 except (TimeoutError, RuntimeError) as e:
-                    __bprint(f"LA wait warning: {e}")
+                    __log_event(f"LA wait warning: {e}")
 
             if ok and mod is not None and hasattr(mod, "decode") and scene_la is not None:
                 t0_decode = time.perf_counter()
                 try:
-                    _call_decode(mod, scene_la, None, None, board.baud, test_params_yml)
+                    _call_decode(mod, scene_la, None, None, board.debug_baudrate, test_params_yml)
                     elapsed = time.perf_counter() - t0_decode
-                    __bprint(f"PASS decode: {suite_name}{case_tag} ({elapsed:.3f} s)")
+                    __log_event(f"PASS decode: {suite_name}{case_tag} ({elapsed:.3f} s)")
                 except (AssertionError, RuntimeError, KeyError, AttributeError, FileNotFoundError) as e:
                     elapsed = time.perf_counter() - t0_decode
-                    __bprint(f"FAIL decode: {suite_name}{case_tag}: {e} ({elapsed:.3f} s)")
+                    __log_event(f"FAIL decode: {suite_name}{case_tag}: {e} ({elapsed:.3f} s)")
                     overall_pass = False
 
     return overall_pass
+
+
+# ---------------------------------------------------------------------------
+# JUnit XML report
+# ---------------------------------------------------------------------------
+
+def _write_junit_xml(
+    run_dir: Path, overall_pass: bool, suites: list[tuple[str, Path | None]]
+) -> None:
+    """Generate a JUnit XML report at ``run_dir/report.junit.xml``."""
+    import xml.etree.ElementTree as ET
+    from xml.dom import minidom
+
+    n_suites = len(suites)
+    testsuite = ET.Element("testsuite", {
+        "name": "vsf-bench",
+        "tests": str(n_suites),
+        "failures": str(0 if overall_pass else 1),
+        "errors": "0",
+        "time": "0",
+    })
+    for suite_name, _ in suites:
+        tc = ET.SubElement(testsuite, "testcase", {
+            "name": suite_name,
+            "classname": "vsf.test." + suite_name,
+        })
+        if not overall_pass:
+            ET.SubElement(tc, "failure", {
+                "message": f"Suite {suite_name}: FAIL",
+                "type": "AssertionError",
+            })
+
+    xml_str = minidom.parseString(ET.tostring(testsuite)).toprettyxml(indent="  ")
+    report_path = run_dir / "report.junit.xml"
+    report_path.write_text(xml_str)
+    __log_event(f"JUnit XML: {report_path}")
+
+
+# ---------------------------------------------------------------------------
+# Hang recovery
+# ---------------------------------------------------------------------------
+
+_HANG_CONSECUTIVE_THRESHOLD = 2
+
+
+def _try_hang_recovery(board, hang_count: int) -> bool:
+    """Attempt recovery after *hang_count* consecutive suite timeouts.
+
+    Returns True if recovery was attempted, False if unavailable.
+    """
+    if hang_count < _HANG_CONSECUTIVE_THRESHOLD:
+        return False
+    if not board.power or not board.debug_probe:
+        return False
+
+    __log_event(
+        f"Hang detected ({hang_count} consecutive timeouts) — "
+        f"attempting recovery"
+    )
+    try:
+        _board_power_cycle(board, delay_off_s=1.0)
+        __log_event("Recovery: power-cycle OK")
+    except Exception as e:
+        __log_event(f"Recovery: power-cycle failed — {e}")
+        return False
+
+    # Attempt crash dump
+    try:
+        from vsf_bench.debug import DebugSession
+
+        probe_cfg = board.debug_probe
+        with DebugSession(
+            target=probe_cfg.get("target", "cortex_m"),
+            probe=probe_cfg.get("probe"),
+        ) as dbg:
+            dump = dbg.crash_dump()
+        __log_event(f"Recovery: crash-dump — {dump.fault_type}")
+    except Exception as e:
+        __log_event(f"Recovery: crash-dump unavailable — {e}")
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Multi-stage pipeline
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    pipeline: "PipelineConfig",
+    board: "BoardConfig",
+    project_map: dict,
+    test_params_yml: "Path | None" = None,
+) -> bool:
+    """Execute a multi-stage build/flash/test pipeline on *board*.
+
+    Returns True when all stages pass. Raises RuntimeError on first failure.
+    Each stage's build_dir is cached so later stages can reuse build output.
+    """
+    build_cache: dict[str, Path] = {}   # project_name → build_dir
+    n_stages = len(pipeline.stages)
+
+    # Populate board-level params that runners need
+    for _proj in project_map.values():
+        for _rcfg in _proj.runners.values():
+            p = _rcfg.params
+            p.setdefault("program_port", board.program_uart)
+            p.setdefault("debug_port", board.debug_uart)
+            p.setdefault("debug_baudrate", board.debug_baudrate)
+
+    __log_event(f"Pipeline: {pipeline.name} ({pipeline.description})")
+    __log_event(f"Board: {board.name}  Stages: {n_stages}")
+
+    for i, stage in enumerate(pipeline.stages, start=1):
+        project = project_map[stage.project]
+        __log_event(
+            f"[Stage {i}/{n_stages}] {stage.project}: {' + '.join(stage.actions)}"
+        )
+
+        # ── power-cycle before stage ──
+        if stage.power_cycle and board.power:
+            _board_power_cycle(board)
+
+        # ── build ──
+        if "build" in stage.actions:
+            build_dir = build_phase(project)
+            build_cache[stage.project] = build_dir
+
+        # ── flash ──
+        if "flash" in stage.actions:
+            build_dir = build_cache.get(stage.project)
+            if build_dir is None:
+                build_dir = Path(project.build.build_dir)
+                if not build_dir.exists():
+                    raise RuntimeError(
+                        f"[Stage {i}] build dir missing for "
+                        f"'{stage.project}': {build_dir}"
+                    )
+            _pipeline_stage_flash(board, project, build_dir, stage)
+
+        # ── test (placeholder) ──
+        if "test" in stage.actions:
+            __log_event(
+                f"[Stage {i}] test: skipping "
+                f"(test-in-pipeline not yet implemented)"
+            )
+
+        __log_event(f"[Stage {i}/{n_stages}] {stage.project}: OK")
+
+    __log_event(f"Pipeline {pipeline.name}: PASS")
+    return True
+
+
+def _pipeline_stage_flash(board, project, build_dir: Path, stage) -> None:
+    """Flash one pipeline stage, applying flash_overrides + wait_for.
+
+    flash_overrides can override: runner name, artifact, params.
+    wait_for: after flash, open serial and wait for regex match.
+    """
+    from copy import deepcopy
+    from vsf_bench.config import ArtifactConfig
+
+    # Determine runner name (stage override or project default)
+    runner_name = stage.flash_overrides.get("runner") if stage.flash_overrides else None
+    if runner_name is None:
+        runner_name = project.active_runner
+
+    runner_cfg = project.runners.get(runner_name)
+    if runner_cfg is None:
+        avail = list(project.runners.keys())
+        raise RuntimeError(
+            f"Runner '{runner_name}' not found in project "
+            f"'{project.name or stage.project}'. Available: {avail}"
+        )
+
+    # Patch runner config if flash_overrides modify artifact or params
+    if stage.flash_overrides:
+        if "artifact" in stage.flash_overrides or "params" in stage.flash_overrides:
+            runner_cfg = deepcopy(runner_cfg)
+            if "artifact" in stage.flash_overrides:
+                art = stage.flash_overrides["artifact"]
+                runner_cfg.artifact = ArtifactConfig(
+                    name=art["name"],
+                    format=art.get("format", "bin"),
+                )
+            if "params" in stage.flash_overrides:
+                runner_cfg.params.update(stage.flash_overrides["params"])
+
+    # Execute flash via the existing program_phase
+    runner_cls = get_runner_class(runner_cfg.type)
+    if runner_cls is None:
+        raise RuntimeError(f"Unknown runner type: {runner_cfg.type}")
+    runner = runner_cls(runner_cfg)
+    with runner:
+        __log_event(f"Programming via {runner_name}...")
+        runner.flash(build_dir)
+    __log_event("Program complete")
+
+    # ── wait_for: open serial, wait for log pattern ──
+    if stage.wait_for:
+        __log_event(f"Waiting for log pattern: /{stage.wait_for}/")
+        ser = SerialInstrument(board.debug_uart, board.debug_baudrate)
+        try:
+            ser.open()
+            ser.expect(stage.wait_for, timeout=60.0)
+            __log_event(f"Log pattern matched: {stage.wait_for}")
+        except TimeoutError:
+            raise RuntimeError(
+                f"Timeout waiting for /{stage.wait_for}/ after flash "
+                f"(board {board.name}, serial {board.debug_uart})"
+            )
+        finally:
+            ser.close()
+
+
+# ---------------------------------------------------------------------------
+# Multi-board test (Phase 12)
+# ---------------------------------------------------------------------------
+
+def _load_all_connected_boards(hardware_map_path: str) -> list:
+    """Return all connected boards from hardware-map.yml."""
+    from vsf_bench.hardware_map import load as _load_hw
+    import yaml
+    with open(hardware_map_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    board_entries = raw.get("boards", [])
+    boards = []
+    for entry in board_entries:
+        if entry.get("connected", True):
+            board = _load_hw(hardware_map_path, board_name=entry.get("name"))
+            boards.append(board)
+    return boards
+
+
+def run_test_phase_all(
+    hardware_map_path: str,
+    project_name: str,
+    suite_names: list[str] | None = None,
+    la_mode: str = "shared",
+    log_dir: str | None = None,
+    trace_level: str = "debug",
+    timeout_per_board: float = 600.0,
+) -> dict[str, bool]:
+    """Run test phase on all connected boards in parallel.
+
+    Returns ``{board_name: passed}`` dict.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from vsf_bench.hardware_map import load_board_and_project
+
+    boards = _load_all_connected_boards(hardware_map_path)
+    if not boards:
+        raise RuntimeError("No connected boards found")
+
+    __log_event(f"Multi-board test: {len(boards)} boards, project={project_name}")
+
+    def _run_one(board):
+        board_dir = str(Path(hardware_map_path).parent)
+        try:
+            lock = acquire_board_lock(board, wait_spec=-1.0)  # wait indefinitely
+        except LockBusyError:
+            __log_event(f"[{board.name}] SKIP: board locked")
+            return board.name, False
+        try:
+            _, project = load_board_and_project(
+                hardware_map_path, board_name=board.name, project_name=project_name,
+            )
+            build_dir = build_phase(project)
+            program_phase(board, build_dir, project=project)
+            ok = run_test_phase(
+                board=board,
+                suite_names=suite_names,
+                script_override=None,
+                case_specs=[],
+                la_mode=la_mode,
+                log_dir=Path(log_dir) / board.name if log_dir else None,
+                shuffle_seed=None,
+                test_params_yml=None,
+                trace_level=trace_level,
+            )
+            return board.name, ok
+        except Exception as e:
+            __log_event(f"[{board.name}] ERROR: {e}")
+            return board.name, False
+        finally:
+            if lock:
+                lock.release()
+
+    results: dict[str, bool] = {}
+    with ThreadPoolExecutor(max_workers=len(boards)) as executor:
+        futures = {executor.submit(_run_one, b): b for b in boards}
+        for future in as_completed(futures):
+            name, ok = future.result()
+            results[name] = ok
+            __log_event(f"[{name}] {'PASS' if ok else 'FAIL'}")
+
+    passed = sum(1 for v in results.values() if v)
+    __log_event(f"Multi-board: {passed}/{len(results)} boards PASS")
+    return results

--- a/test/vsf_bench/pyproject.toml
+++ b/test/vsf_bench/pyproject.toml
@@ -10,8 +10,13 @@ dependencies = [
 [project.scripts]
 vsf-bench       = "vsf_bench.cli.run:main"
 vsf-bench-build = "vsf_bench.cli.build:main"
-vsf-bench-flash = "vsf_bench.cli.flash:main"
+vsf-bench-program = "vsf_bench.cli.program:main"
 vsf-bench-test  = "vsf_bench.cli.test:main"
+vsf-bench-debug = "vsf_bench.cli.debug:main"
+
+[project.optional-dependencies]
+debug = ["pyocd"]
+gpio = ["pyftdi"]
 
 [build-system]
 requires = ["setuptools>=68"]
@@ -27,6 +32,8 @@ packages = [
     "vsf_bench.instruments",
     "vsf_bench.runners",
     "vsf_bench.builders",
+    "vsf_bench.capabilities",
+    "vsf_bench.adapters",
 ]
 
 [tool.setuptools.package-dir]
@@ -34,3 +41,5 @@ packages = [
 "vsf_bench.cli" = "cli"
 "vsf_bench.instruments" = "instruments"
 "vsf_bench.runners" = "runners"
+"vsf_bench.capabilities" = "capabilities"
+"vsf_bench.adapters" = "adapters"

--- a/test/vsf_bench/runners/base.py
+++ b/test/vsf_bench/runners/base.py
@@ -1,34 +1,11 @@
-"""FlashRunner — abstract base class for all flash runner backends.
+"""FlashRunner — backward-compat alias for ProgramCapability.
 
-Custom runners (post-MVP) must inherit from this class and implement flash().
+New adapters implement ``capabilities.program.ProgramCapability`` directly.
+This module exists so existing runners (PluginRunner, SWD, UF2) don't break.
 """
 
-from abc import ABC, abstractmethod
-from pathlib import Path
-
-from vsf_bench.config import RunnerConfig
+from vsf_bench.capabilities.program import ProgramCapability
 
 
-class FlashRunner(ABC):
-    """Abstract base for flash runners.
-
-    Subclasses must:
-    - Set REQUIRED_PARAMS: list of param keys that must exist in hardware-map.yml
-    - Implement flash(build_dir): flash firmware to the target board
-    - Optionally override validate_params(params) for type-specific checks
-    """
-
-    REQUIRED_PARAMS: list[str] = []
-
-    def __init__(self, config: RunnerConfig):
-        self._config = config
-
-    @abstractmethod
-    def flash(self, build_dir: Path) -> None:
-        """Flash firmware to the target board."""
-        ...
-
-    @classmethod
-    def validate_params(cls, params: dict) -> list[str]:
-        """Extra validation beyond REQUIRED_PARAMS. Returns list of error strings."""
-        return []
+class FlashRunner(ProgramCapability):
+    """Backward-compat shim.  Prefer extending ProgramCapability for new code."""

--- a/test/vsf_bench/runners/plugin_runner.py
+++ b/test/vsf_bench/runners/plugin_runner.py
@@ -1,0 +1,89 @@
+"""PluginRunner — dynamically load a flash runner from an external module.
+
+This is the key name-isolation mechanism: vsf-bench code never imports or
+mentions ``bh1098_flash`` or ``BH1098UartFlashRunner``.  Instead,
+``hardware-map.yml`` (in the private repository) specifies ``module`` and
+``class`` names, and PluginRunner loads them via ``importlib`` at runtime.
+"""
+
+import importlib
+from pathlib import Path
+
+from vsf_bench.config import RunnerConfig
+from vsf_bench.runners.base import FlashRunner
+
+
+class PluginRunner(FlashRunner):
+    """Dynamically loads a FlashRunner subclass from an external Python module.
+
+    Required params (set in hardware-map.yml):
+      * ``module``: dotted Python module path (e.g. ``"scripts.bh1098_flash"``)
+      * ``class``: class name inside that module
+    """
+
+    REQUIRED_PARAMS = ["module", "class"]
+
+    def __init__(self, config: RunnerConfig):
+        super().__init__(config)
+        self._module_name = config.params["module"]
+        self._class_name = config.params["class"]
+        self._delegate = None
+
+    def _load_delegate(self) -> FlashRunner:
+        if self._delegate is None:
+            mod = self._resolve_module(self._module_name)
+            cls = getattr(mod, self._class_name, None)
+            if cls is None:
+                raise RuntimeError(
+                    f"PluginRunner: module '{self._module_name}' has no "
+                    f"class '{self._class_name}'"
+                )
+            self._delegate = cls(self._config)
+        return self._delegate
+
+    @staticmethod
+    def _resolve_module(module_name: str):
+        """Import *module_name*, auto-discovering the private repo root.
+
+        Tries ``importlib.import_module`` first.  On ImportError, walks
+        upward from cwd looking for a directory that contains the first
+        component of *module_name* (e.g. ``scripts/``), adds it to
+        ``sys.path``, and retries.
+        """
+        import sys as _sys
+
+        try:
+            return importlib.import_module(module_name)
+        except ImportError:
+            pass
+
+        # Search upward for the private repo root
+        top_pkg = module_name.split(".")[0]
+        search = Path.cwd()
+        while True:
+            candidate = search / top_pkg
+            if candidate.is_dir() or (search / f"{top_pkg}.py").exists():
+                repo_root = str(search)
+                if repo_root not in _sys.path:
+                    _sys.path.insert(0, repo_root)
+                return importlib.import_module(module_name)
+            parent = search.parent
+            if parent == search:
+                break
+            search = parent
+
+        raise RuntimeError(
+            f"PluginRunner: cannot import '{module_name}'. "
+            f"Tried cwd upward search — not found. "
+            f"Verify the private repo is accessible from cwd."
+        )
+
+    def prepare(self) -> None:
+        self._load_delegate().prepare()
+
+    def close(self) -> None:
+        if self._delegate is not None:
+            self._delegate.close()
+
+    def flash(self, build_dir: Path) -> None:
+        self._load_delegate().flash(build_dir)

--- a/test/vsf_bench/runners/registry.py
+++ b/test/vsf_bench/runners/registry.py
@@ -6,10 +6,14 @@ import from here. Add new built-in runners here.
 
 from vsf_bench.runners.swd_runner import SWDRunner
 from vsf_bench.runners.uf2_runner import UF2Runner
+from vsf_bench.runners.plugin_runner import PluginRunner
+from vsf_bench.adapters.dfu import DFUAdapter
 
 RUNNER_TYPES: dict[str, type] = {
     "openocd": SWDRunner,
+    "plugin": PluginRunner,
     "uf2": UF2Runner,
+    "dfu": DFUAdapter,
 }
 
 

--- a/test/vsf_bench/suite.py
+++ b/test/vsf_bench/suite.py
@@ -102,3 +102,68 @@ def resolve_suites(
                 )
         return ordered
     return [(name, discovered[name]) for name in sorted(discovered.keys())]
+
+
+# ---------------------------------------------------------------------------
+# PeripheralType auto-gen from vsf_test.h
+# ---------------------------------------------------------------------------
+
+_PERIPHERAL_ENUM_RE = r"^\s*VSF_PERIPHERAL_TYPE_(\w+)\s*(?:=\s*(\d+))?,?"
+
+
+def _find_vsf_test_header() -> Path | None:
+    """Locate vsf_test.h relative to vsf-bench package."""
+    candidates = [
+        # vsf submodule layout
+        Path(__file__).resolve().parent / ".." / ".." / ".." / ".."
+        / "source" / "component" / "test" / "vsf_test" / "vsf_test.h",
+    ]
+    for p in candidates:
+        if p.exists():
+            return p.resolve()
+    return None
+
+
+def generate_peripheral_type_enum() -> type:
+    """Parse ``vsf_test.h`` and return a Python ``PeripheralType`` IntEnum.
+
+    Returns a dynamically created enum whose members match the C enum
+    ``vsf_peripheral_type_t``.  Cached after first call.
+    """
+    import re
+    from enum import IntEnum
+
+    header = _find_vsf_test_header()
+    if header is None:
+        # Fallback: empty enum so import doesn't fail
+        return IntEnum("PeripheralType", {"NONE": 0})
+
+    content = header.read_text(encoding="utf-8", errors="replace")
+    # Find the enum block
+    m = re.search(
+        r"typedef\s+enum\s+vsf_peripheral_type_t\s*\{(.*?)\}\s*vsf_peripheral_type_t",
+        content, re.DOTALL,
+    )
+    if not m:
+        return IntEnum("PeripheralType", {"NONE": 0})
+
+    members: dict[str, int] = {}
+    auto_val = 0
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("//") or line.startswith("/*"):
+            continue
+        # Match VSF_PERIPHERAL_TYPE_XXX or VSF_PERIPHERAL_TYPE_XXX = N
+        mm = re.match(r"VSF_PERIPHERAL_TYPE_(\w+)\s*(?:=\s*(-?\d+))?\s*,?", line)
+        if mm:
+            name = mm.group(1)
+            if mm.group(2) is not None:
+                auto_val = int(mm.group(2))
+            members[name] = auto_val
+            auto_val += 1
+
+    return IntEnum("PeripheralType", members)  # type: ignore[arg-type]
+
+
+# Module-level cache
+PeripheralType = generate_peripheral_type_enum()

--- a/test/vsf_bench/test_params_loader.py
+++ b/test/vsf_bench/test_params_loader.py
@@ -179,6 +179,42 @@ def load_yaml_with_includes(
     return _apply_defaults(merged)
 
 
+def validate_test_params(params: dict) -> list[str]:
+    """Validate test_params structure, returning a list of error messages.
+
+    Catches missing required fields, wrong types, empty cases.
+    Returns empty list if valid.
+    """
+    errors = []
+    if not isinstance(params, dict):
+        return ["test_params root must be a dict"]
+
+    for scenario_name, scenario in params.items():
+        if scenario_name == "marker":
+            continue
+        if not isinstance(scenario, dict):
+            errors.append(f"{scenario_name}: must be a dict")
+            continue
+        if "name" not in scenario:
+            errors.append(f"{scenario_name}: missing 'name'")
+        if "cases" not in scenario:
+            errors.append(f"{scenario_name}: missing 'cases'")
+            continue
+        cases = scenario["cases"]
+        if not isinstance(cases, list):
+            errors.append(f"{scenario_name}.cases: must be a list")
+            continue
+        if not cases:
+            errors.append(f"{scenario_name}.cases: empty")
+        for i, case in enumerate(cases):
+            if not isinstance(case, dict):
+                errors.append(f"{scenario_name}.cases[{i}]: must be a dict")
+                continue
+            if "idx" not in case:
+                errors.append(f"{scenario_name}.cases[{i}]: missing 'idx'")
+    return errors
+
+
 def load_test_params(
     test_params_yml: str | Path,
     board_pins_path: str | Path | None = None,

--- a/test/vsf_bench/vsf_test_shell.py
+++ b/test/vsf_bench/vsf_test_shell.py
@@ -1,0 +1,108 @@
+"""VsfTestShellProtocol — 固件 vsf-test shell 串口协议封装。
+
+从 pipeline.py 提取纯 shell 对话逻辑（字符串级别的命令/响应），
+不包含测试编排、日志、LA 等 pipeline 职责。
+
+Usage::
+
+    from vsf_bench.vsf_test_shell import VsfTestShellProtocol
+    shell = VsfTestShellProtocol(ser)
+    suites = shell.query_firmware_suites()
+    shell.wait_for_shell_ready()
+"""
+
+import time
+
+from vsf_bench.instruments.serial_instrument import SerialInstrument
+
+
+class VsfTestShellProtocol:
+    """vs-test firmware shell 协议 — 命令发送、响应解析、REPL 管理。
+
+    所有方法通过 *ser* (SerialInstrument) 和固件对话。
+    调用方持有 SerialInstrument 的生命周期。
+    """
+
+    def __init__(self, ser: SerialInstrument):
+        self._ser = ser
+
+    # ── 固件查询 ──────────────────────────────────────────
+
+    def query_firmware_suites(self) -> set[str]:
+        """发送 ``vsf-test list-suites``，解析返回的 suite 名列表。"""
+        self._ser.send("vsf-test list-suites\r\n")
+        time.sleep(0.3)
+        output = self._ser.read_all(timeout=2.0)
+        suites: set[str] = set()
+        for line in output.splitlines():
+            line = line.strip()
+            if line and line[0].isdigit():
+                parts = line.split(None, 1)
+                if len(parts) == 2:
+                    suites.add(parts[1])
+        return suites
+
+    # ── REPL 管理 ─────────────────────────────────────────
+
+    def drain_repl(self) -> None:
+        """丢弃串口缓冲区中的残留数据。"""
+        self._ser.read_all(timeout=0.1)
+
+    def wait_for_shell_ready(self, timeout: float = 2.0) -> bool:
+        """等待 ``> `` 提示符出现，最多 3 次尝试。返回是否成功。"""
+        self.drain_repl()
+        self._ser.send("\r\n")
+        for _attempt in range(3):
+            try:
+                self._ser.expect("> ", timeout=timeout)
+                return True
+            except TimeoutError:
+                self.drain_repl()
+                self._ser.send("\r\n")
+        return False
+
+    # ── trace level ───────────────────────────────────────
+
+    def set_trace_level(self, level: str) -> bool:
+        """发送 ``vsf-test trace-level <level>`` 并等待确认。"""
+        self._ser.send(f"vsf-test trace-level {level}\r\n")
+        try:
+            self._ser.expect("trace-level set:", timeout=1.0)
+            return True
+        except TimeoutError:
+            # ack 可能混在下一个 prompt 里
+            self._ser.read_all(timeout=0.3)
+            return True  # 保守视为成功
+
+    # ── suite 命令构建 ────────────────────────────────────
+
+    @staticmethod
+    def build_run_cmd(suite: str, case: str | None = None) -> str:
+        """构建 ``vsf-test run-suite`` 或 ``vsf-test run-case`` 命令。"""
+        if case:
+            return f"vsf-test run-case {suite} {case}\r\n"
+        return f"vsf-test run-suite {suite}\r\n"
+
+    # ── suite ack ─────────────────────────────────────────
+
+    SUITE_ACK_PATTERN = (
+        r"\[vsf-test\](?: \[\d+\.\d+ s\])? suite ack:"
+        r"|"
+        r"\[vsf-test\](?: \[\d+\.\d+ s\])? suite not found:"
+        r"|"
+        r"\[vsf-test\](?: \[\d+\.\d+ s\])? case not found:"
+    )
+
+    def expect_suite_ack(self, timeout: float = 1.0) -> str | None:
+        """等待 suite ack / not-found 响应。超时返回 None。"""
+        try:
+            return self._ser.expect(self.SUITE_ACK_PATTERN, timeout=timeout)
+        except TimeoutError:
+            return None
+
+    # ── shuffle seed (no-op, 向后兼容) ────────────────────
+
+    def send_shuffle_seed(self, suite_name: str, seed: int) -> bool:
+        """Shuffle seed 通知（当前固件不支持，host 端处理）。"""
+        # 向后兼容 CLI --random --seed 参数
+        return True


### PR DESCRIPTION
## Summary

Add vsf-bench, a hardware-in-the-loop automation tool for VSF firmware, plus a DFU fix and agent skill documentation.

### Changes

**[vsf] dfu: handle GETSTATE in MANIFEST state for manifestation-complete transition**
- Fix DFU firmware update sequence when device receives DFU_GETSTATUS in MANIFEST state

**[test/vsf_bench] add vsf-bench: automated build, program, test, and debug tool**
- YAML-based board/project configuration (hardware-map.yml)
- IAR builder: auto-detect IarBuild.exe, direct invocation
- PluginRunner: dynamic import for private runner scripts
- TeeLogger: thread-safe singleton logger
- USB hub power control: power-cycle target boards
- DFU runner: dfu-util wrapper with FT232H GPIO for DFU key
- Serial port matching by VID/PID/serial/desc
- Test pipeline: build → program → test orchestration
- VsfTestShellProtocol: firmware shell protocol wrapper
- DebugSession: pyOCD-based crash dump, backtrace, register dump
- Multi-board parallel test with ThreadPoolExecutor
- Hang recovery: timeout → power cycle → crash dump
- JUnit XML report generation
- Capabilities/adapters architecture: ProgramCapability, GPIO
- CLI: vsf-bench build|program|test|run, vsf-bench-debug

**[document/skill] add vsf-bench agent skill for Claude Code**
- Skill definition with build, program, test, and pipeline commands