### PR TITLE
[ci] support vs2026 on windows-2025 runner, upgrade actions versions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -18,19 +18,19 @@ jobs:
         build_config: [Debug]
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2019
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2022
-        vs-version: ['[17.0, 18)']
+        vs-version: ['[17.0, 19)']
         os: [windows-2022, windows-2025]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3
+      uses: microsoft/setup-msbuild@v3
       with:
         vs-version: ${{ matrix.vs-version }}
 
     - name: Checkout With Submodule
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true # without recursive
 


### PR DESCRIPTION
## Summary

Fix **vsf windows build** CI failure on `windows-2025` runners.

## Root Cause

`windows-2025` runner image now ships with **Visual Studio 2026** (version 18.x), but the workflow's `vs-version: '[17.0, 18)'` only matches VS 2022 (17.x), causing `vswhere.exe` to fail with `Unable to find MSBuild`.

## Changes

- `vs-version`: `[17.0, 18)` → `[17.0, 19)` — cover VS 2026 version 18.x
- `microsoft/setup-msbuild`: `@v1.3` → `@v3` — latest version
- `actions/checkout`: `@v2` → `@v4` — latest major version