### PR TITLE
[shell/linux/glibc] use strong symbols for wmem* to fix lld-link on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -18,19 +18,19 @@ jobs:
         build_config: [Debug]
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2019
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2022
-        vs-version: ['[17.0, 18)']
+        vs-version: ['[17.0, 19)']
         os: [windows-2022, windows-2025]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3
+      uses: microsoft/setup-msbuild@v3
       with:
         vs-version: ${{ matrix.vs-version }}
 
     - name: Checkout With Submodule
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true # without recursive
 

--- a/source/shell/sys/linux/lib/glibc/vsf_linux_glibc.c
+++ b/source/shell/sys/linux/lib/glibc/vsf_linux_glibc.c
@@ -307,7 +307,7 @@ __VSF_VPLT_DECORATOR__ vsf_linux_libc_math_vplt_t vsf_linux_libc_math_vplt = {
 
 #if VSF_LINUX_APPLET_USE_LIBC_WCHAR == ENABLED && !defined(__VSF_APPLET__)
 
-VSF_CAL_WEAK(wmemset)
+// use strong symbol for lld-link on Windows
 wchar_t * wmemset(wchar_t *dest, wchar_t c, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -316,7 +316,7 @@ wchar_t * wmemset(wchar_t *dest, wchar_t c, size_t n)
     return dest;
 }
 
-VSF_CAL_WEAK(wmemchr)
+// use strong symbol for lld-link on Windows
 wchar_t * wmemchr(const wchar_t *str, wchar_t c, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -327,7 +327,7 @@ wchar_t * wmemchr(const wchar_t *str, wchar_t c, size_t n)
     return NULL;
 }
 
-VSF_CAL_WEAK(wmemcmp)
+// use strong symbol for lld-link on Windows
 int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -338,7 +338,7 @@ int wmemcmp(const wchar_t *s1, const wchar_t *s2, size_t n)
     return 0;
 }
 
-VSF_CAL_WEAK(wmemcpy)
+// use strong symbol for lld-link on Windows
 wchar_t * wmemcpy(wchar_t *dest, const wchar_t *src, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -347,7 +347,7 @@ wchar_t * wmemcpy(wchar_t *dest, const wchar_t *src, size_t n)
     return dest;
 }
 
-VSF_CAL_WEAK(wmemmove)
+// use strong symbol for lld-link on Windows
 wchar_t * wmemmove(wchar_t *dest, const wchar_t *src, size_t n)
 {
     if (dest < src) {

--- a/source/shell/sys/linux/port/busybox/busybox.c
+++ b/source/shell/sys/linux/port/busybox/busybox.c
@@ -68,6 +68,31 @@ int vsf_linux_init_main(int argc, char *argv[])
     vsh_run_scripts(VSF_LINUX_CFG_INIT_SCRIPT_FILE);
 #endif
 
+    // system() spawns child processes which share stdio fds via ref-counted
+    // priv pointers. Ensure stdin/stdout are still available before starting shell.
+    extern vsf_linux_fd_t * vsf_linux_fd_get(int fd);
+    if (NULL == vsf_linux_fd_get(STDIN_FILENO)) {
+        extern int __vsf_linux_fd_create_ex(vsf_linux_process_t *process,
+            vsf_linux_fd_t **sfd, const vsf_linux_fd_op_t *op, int fd_min,
+            vsf_linux_fd_priv_t *priv);
+        extern vsf_linux_fd_t * __vsf_linux_fd_get_ex(vsf_linux_process_t *process, int fd);
+        extern vsf_linux_process_t * vsf_linux_get_res_process(void);
+        vsf_linux_fd_t *sfd_from = __vsf_linux_fd_get_ex(vsf_linux_get_res_process(), STDIN_FILENO);
+        if (sfd_from != NULL) {
+            vsf_linux_fd_t *sfd;
+            __vsf_linux_fd_create_ex(NULL, &sfd, sfd_from->op, STDIN_FILENO, sfd_from->priv);
+        }
+    }
+    if (NULL == vsf_linux_fd_get(STDOUT_FILENO)) {
+        extern vsf_linux_fd_t * __vsf_linux_fd_get_ex(vsf_linux_process_t *process, int fd);
+        extern vsf_linux_process_t * vsf_linux_get_res_process(void);
+        vsf_linux_fd_t *sfd_from = __vsf_linux_fd_get_ex(vsf_linux_get_res_process(), STDOUT_FILENO);
+        if (sfd_from != NULL) {
+            vsf_linux_fd_t *sfd;
+            __vsf_linux_fd_create_ex(NULL, &sfd, sfd_from->op, STDOUT_FILENO, sfd_from->priv);
+        }
+    }
+
     return vsh_main(argc, argv);
 }
 

--- a/source/shell/sys/linux/port/busybox/busybox.c
+++ b/source/shell/sys/linux/port/busybox/busybox.c
@@ -68,31 +68,6 @@ int vsf_linux_init_main(int argc, char *argv[])
     vsh_run_scripts(VSF_LINUX_CFG_INIT_SCRIPT_FILE);
 #endif
 
-    // system() spawns child processes which share stdio fds via ref-counted
-    // priv pointers. Ensure stdin/stdout are still available before starting shell.
-    extern vsf_linux_fd_t * vsf_linux_fd_get(int fd);
-    if (NULL == vsf_linux_fd_get(STDIN_FILENO)) {
-        extern int __vsf_linux_fd_create_ex(vsf_linux_process_t *process,
-            vsf_linux_fd_t **sfd, const vsf_linux_fd_op_t *op, int fd_min,
-            vsf_linux_fd_priv_t *priv);
-        extern vsf_linux_fd_t * __vsf_linux_fd_get_ex(vsf_linux_process_t *process, int fd);
-        extern vsf_linux_process_t * vsf_linux_get_res_process(void);
-        vsf_linux_fd_t *sfd_from = __vsf_linux_fd_get_ex(vsf_linux_get_res_process(), STDIN_FILENO);
-        if (sfd_from != NULL) {
-            vsf_linux_fd_t *sfd;
-            __vsf_linux_fd_create_ex(NULL, &sfd, sfd_from->op, STDIN_FILENO, sfd_from->priv);
-        }
-    }
-    if (NULL == vsf_linux_fd_get(STDOUT_FILENO)) {
-        extern vsf_linux_fd_t * __vsf_linux_fd_get_ex(vsf_linux_process_t *process, int fd);
-        extern vsf_linux_process_t * vsf_linux_get_res_process(void);
-        vsf_linux_fd_t *sfd_from = __vsf_linux_fd_get_ex(vsf_linux_get_res_process(), STDOUT_FILENO);
-        if (sfd_from != NULL) {
-            vsf_linux_fd_t *sfd;
-            __vsf_linux_fd_create_ex(NULL, &sfd, sfd_from->op, STDOUT_FILENO, sfd_from->priv);
-        }
-    }
-
     return vsh_main(argc, argv);
 }
 


### PR DESCRIPTION
## Summary

VS 2026 uses LLVM toolchain (clang-cl + lld-link). The `VSF_CAL_WEAK` attribute on wmem* functions causes `_wmemchr` (and other wmem* symbols) to not be exported with the `_` prefix expected by Windows ABI, resulting in:

```
lld-link : error : undefined symbol: _wmemchr
```

## Fix

Remove `VSF_CAL_WEAK` from all 5 wmem* functions in glibc and make them strong symbols. These are standard C library functions that should always be available.

## Verification

- vsf.linux fork CI: native build ✅, arm cross build ✅ (with this fix as submodule)