### PR TITLE
[test/hal] adc oneshot/temperature: wait for async completion

### DIFF
--- a/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_oneshot.c
+++ b/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_oneshot.c
@@ -34,7 +34,19 @@ const struct vsf_test_adc_oneshot_s {
 
 /*============================ LOCAL VARIABLES ===============================*/
 
+static volatile bool __adc_oneshot_completed = false;
+
 /*============================ IMPLEMENTATION ================================*/
+
+static void __adc_oneshot_isr(void *target_ptr, vsf_adc_t *adc_ptr,
+                              vsf_adc_irq_mask_t irq_mask)
+{
+    VSF_UNUSED_PARAM(target_ptr);
+    VSF_UNUSED_PARAM(adc_ptr);
+    if (irq_mask & VSF_ADC_IRQ_MASK_CPL) {
+        __adc_oneshot_completed = true;
+    }
+}
 
 void vsf_test_adc_oneshot_run(const vsf_test_suite_t *suite, const vsf_test_case_t *tc, const vsf_test_inst_t *inst)
 {
@@ -69,7 +81,11 @@ void vsf_test_adc_oneshot_run(const vsf_test_suite_t *suite, const vsf_test_case
     VSF_TEST_TRACE_DEBUG("adc_oneshot:vsf_adc_init" VSF_TRACE_CFG_LINEEND);
     vsf_adc_cfg_t cfg = {
         .mode     = VSF_TEST_ADC_ONESHOT_MODE,
-        .isr      = {NULL, NULL, 0},
+        .isr      = {
+            .handler_fn = __adc_oneshot_isr,
+            .target_ptr = NULL,
+            .prio       = VSF_TEST_ADC_ONESHOT_PRIO,
+        },
         .clock_hz = VSF_TEST_ADC_CLOCK_HZ,
     };
     vsf_err_t err = vsf_adc_init(adc, &cfg);
@@ -91,10 +107,22 @@ void vsf_test_adc_oneshot_run(const vsf_test_suite_t *suite, const vsf_test_case
         .sample_cycles = VSF_TEST_ADC_ONESHOT_SAMPLE_CYCLES,
     };
     uint16_t sample = 0;
+    __adc_oneshot_completed = false;
     err = vsf_adc_channel_request_once(adc, &ch_cfg, &sample);
     VSF_TEST_ASSERT_ERR_NONE(err,
         "adc_oneshot:vsf_adc_channel_request_once failed (err=%d) (ch=%u)"
                              VSF_TRACE_CFG_LINEEND, (int)err, (unsigned)ch_cfg.channel);
+
+    // vsf_adc_channel_request_once is asynchronous: wait for the conversion-complete
+    // interrupt (VSF_ADC_IRQ_MASK_CPL) before reading the result.
+    VSF_TEST_TRACE_DEBUG("adc_oneshot:waiting for completion" VSF_TRACE_CFG_LINEEND);
+    VSF_TEST_WAIT_FOR(__adc_oneshot_completed, VSF_TEST_ADC_ONESHOT_TIMEOUT_MS);
+    if (!__adc_oneshot_completed) {
+        VSF_TEST_TRACE_ERROR("adc_oneshot:conversion timeout after %u ms"
+                             VSF_TRACE_CFG_LINEEND,
+                             (unsigned)VSF_TEST_ADC_ONESHOT_TIMEOUT_MS);
+    }
+    VSF_TEST_ASSERT(__adc_oneshot_completed);
 
     // Result must be within 12-bit range
     if (sample > VSF_TEST_ADC_ONESHOT_MAX_SAMPLE) {

--- a/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_oneshot.h
+++ b/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_oneshot.h
@@ -40,6 +40,14 @@
 #   define VSF_TEST_ADC_ONESHOT_SAMPLE_CYCLES           0
 #endif
 
+#ifndef VSF_TEST_ADC_ONESHOT_PRIO
+#   define VSF_TEST_ADC_ONESHOT_PRIO                    vsf_arch_prio_1
+#endif
+
+#ifndef VSF_TEST_ADC_ONESHOT_TIMEOUT_MS
+#   define VSF_TEST_ADC_ONESHOT_TIMEOUT_MS             500
+#endif
+
 
 #ifndef VSF_TEST_ADC_CLOCK_HZ
 #   define VSF_TEST_ADC_CLOCK_HZ               48000000

--- a/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_temperature.c
+++ b/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_temperature.c
@@ -36,7 +36,19 @@ const struct vsf_test_adc_temperature_s {
 
 /*============================ LOCAL VARIABLES ===============================*/
 
+static volatile bool __adc_temperature_completed = false;
+
 /*============================ IMPLEMENTATION ================================*/
+
+static void __adc_temperature_isr(void *target_ptr, vsf_adc_t *adc_ptr,
+                                  vsf_adc_irq_mask_t irq_mask)
+{
+    VSF_UNUSED_PARAM(target_ptr);
+    VSF_UNUSED_PARAM(adc_ptr);
+    if (irq_mask & VSF_ADC_IRQ_MASK_CPL) {
+        __adc_temperature_completed = true;
+    }
+}
 
 void vsf_test_adc_temperature_run(const vsf_test_suite_t *suite, const vsf_test_case_t *tc, const vsf_test_inst_t *inst)
 {
@@ -62,7 +74,11 @@ void vsf_test_adc_temperature_run(const vsf_test_suite_t *suite, const vsf_test_
     VSF_TEST_TRACE_DEBUG("adc_temperature:vsf_adc_init" VSF_TRACE_CFG_LINEEND);
     vsf_adc_cfg_t cfg = {
         .mode     = VSF_TEST_ADC_TEMPERATURE_MODE,
-        .isr      = {NULL, NULL, 0},
+        .isr      = {
+            .handler_fn = __adc_temperature_isr,
+            .target_ptr = NULL,
+            .prio       = VSF_TEST_ADC_TEMPERATURE_PRIO,
+        },
         .clock_hz = VSF_TEST_ADC_CLOCK_HZ,
     };
     vsf_err_t err = vsf_adc_init(adc, &cfg);
@@ -83,10 +99,22 @@ void vsf_test_adc_temperature_run(const vsf_test_suite_t *suite, const vsf_test_
         .sample_cycles = VSF_TEST_ADC_TEMPERATURE_SAMPLE_CYCLES,
     };
     uint16_t sample = 0;
+    __adc_temperature_completed = false;
     err = vsf_adc_channel_request_once(adc, &ch_cfg, &sample);
     VSF_TEST_ASSERT_ERR_NONE(err,
         "adc_temperature:vsf_adc_channel_request_once failed (err=%d) (ch=%u)"
                              VSF_TRACE_CFG_LINEEND, (int)err, (unsigned)ch_cfg.channel);
+
+    // vsf_adc_channel_request_once is asynchronous: wait for the conversion-complete
+    // interrupt (VSF_ADC_IRQ_MASK_CPL) before reading the result.
+    VSF_TEST_TRACE_DEBUG("adc_temperature:waiting for completion" VSF_TRACE_CFG_LINEEND);
+    VSF_TEST_WAIT_FOR(__adc_temperature_completed, VSF_TEST_ADC_TEMPERATURE_TIMEOUT_MS);
+    if (!__adc_temperature_completed) {
+        VSF_TEST_TRACE_ERROR("adc_temperature:conversion timeout after %u ms"
+                             VSF_TRACE_CFG_LINEEND,
+                             (unsigned)VSF_TEST_ADC_TEMPERATURE_TIMEOUT_MS);
+    }
+    VSF_TEST_ASSERT(__adc_temperature_completed);
 
     /* Verify raw value is within 12-bit range. Temperature varies by
      * environment and VREF tolerance, so no tight bounds. */

--- a/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_temperature.h
+++ b/test/vsf_test_suite/hal/driver/adc/suite/vsf_test_adc_temperature.h
@@ -30,6 +30,14 @@
 #   define VSF_TEST_ADC_TEMPERATURE_SAMPLE_CYCLES             0
 #endif
 
+#ifndef VSF_TEST_ADC_TEMPERATURE_PRIO
+#   define VSF_TEST_ADC_TEMPERATURE_PRIO                     vsf_arch_prio_1
+#endif
+
+#ifndef VSF_TEST_ADC_TEMPERATURE_TIMEOUT_MS
+#   define VSF_TEST_ADC_TEMPERATURE_TIMEOUT_MS               500
+#endif
+
 
 #ifndef VSF_TEST_ADC_CLOCK_HZ
 #   define VSF_TEST_ADC_CLOCK_HZ                   48000000


### PR DESCRIPTION
> **Draft — not yet tested on hardware.**

## Summary

`vsf_adc_channel_request_once` is an **asynchronous** API: the conversion
result is delivered via the `VSF_ADC_IRQ_MASK_CPL` ISR callback, not by the
time the call returns.

The `adc_oneshot` and `adc_temperature` test suites registered no ISR
(`cfg.isr = {NULL, NULL, 0}`) and read the sample **immediately** after the
request — i.e. they used the async API as if it were synchronous.

## Change

Mirror the correct pattern already used by `vsf_test_adc_stream.c`:
- register a completion ISR that sets a `volatile bool` flag on `VSF_ADC_IRQ_MASK_CPL`;
- clear the flag before the request;
- `VSF_TEST_WAIT_FOR(...)` the conversion-complete interrupt before reading the sample.

Also add per-suite `..._PRIO` (`vsf_arch_prio_1`) and `..._TIMEOUT_MS` (500)
config defaults (overridable), matching the stream suite's convention.

Files:
- `test/.../adc/suite/vsf_test_adc_oneshot.c` / `.h`
- `test/.../adc/suite/vsf_test_adc_temperature.c` / `.h`

## Status / TODO

- [ ] Build
- [ ] Run on target hardware and confirm both suites pass

Kept as a **draft** until the above verification is done.
